### PR TITLE
fix is_wchar_t<wchar_t*>

### DIFF
--- a/include/boost/process/detail/traits/wchar_t.hpp
+++ b/include/boost/process/detail/traits/wchar_t.hpp
@@ -24,7 +24,7 @@ template<> struct is_wchar_t<boost::filesystem::path> : std::is_same<typename bo
 
 template<> struct is_wchar_t<const wchar_t* > : std::true_type {};
 
-template<> struct is_wchar_t<wchar_t* > { typedef std::true_type type;};
+template<> struct is_wchar_t<wchar_t* > : std::true_type {};
 
 template<std::size_t Size> struct is_wchar_t<const wchar_t [Size]>    : std::true_type {};
 template<std::size_t Size> struct is_wchar_t<const wchar_t (&)[Size]> : std::true_type {};


### PR DESCRIPTION
A small fix for compiling the example.
```
#include <boost/process.hpp>

namespace bp = boost::process;

int main(void)
{
	std::wstring cmd = L"dir";
	bp::child c = bp::child(
		&cmd.front(),
		bp::shell,
		bp::std_out > stdout);
	c.wait();
	return 0;
}
```