### PR TITLE
add char_converter for basic_environment

### DIFF
--- a/include/boost/process/env.hpp
+++ b/include/boost/process/env.hpp
@@ -193,6 +193,23 @@ struct char_converter<wchar_t, env_init<char>>
     }
 };
 
+template<>
+struct char_converter<char, basic_environment<wchar_t>>
+{
+    static basic_environment<char> conv(const basic_environment<wchar_t> & in)
+    {
+        return { basic_environment<char>(in) };
+    }
+};
+
+template<>
+struct char_converter<wchar_t, basic_environment<char>>
+{
+    static basic_environment<wchar_t> conv(const basic_environment<char> & in)
+    {
+        return { basic_environment<wchar_t>(in) };
+    }
+};
 
 template<typename Char>
 struct env_proxy


### PR DESCRIPTION
I added char_converter for basic_environment for compiling the example on Windows.
```
#include <boost/process.hpp>

namespace bp = boost::process;

int main(void)
{
    bp::environment env;
    env["bp_env"] = "boost::process";
    bp::child c = bp::child(
        "echo %bp_env%",
        env,
        bp::shell,
        bp::std_out > stdout);
    c.wait();
    return 0;
}
```