### PR TITLE
fix is_wchar_t<start_dir_init<wchar_t>>

### DIFF
--- a/include/boost/process/start_dir.hpp
+++ b/include/boost/process/start_dir.hpp
@@ -66,7 +66,7 @@ struct start_dir_
 
 };
 
-template<> struct is_wchar_t<api::start_dir_init<wchar_t>> { typedef std::true_type type;};
+template<> struct is_wchar_t<api::start_dir_init<wchar_t>> : std::true_type {};
 
 template<>
 struct char_converter<char, api::start_dir_init<wchar_t>>


### PR DESCRIPTION
A small fix for compiling the example.

```
#include <boost/process.hpp>

namespace bp = boost::process;

int main()
{
    std::wstring cmd = L"dir";
    std::wstring dir = L"C:\\";
    bp::child c = bp::child(cmd, bp::start_dir = dir, bp::shell);
    c.wait();
}
```