### PR TITLE
fix bp::detail::convert for empty string

### DIFF
--- a/include/boost/process/detail/windows/locale.hpp
+++ b/include/boost/process/detail/windows/locale.hpp
@@ -45,10 +45,12 @@ class windows_file_codecvt
              ::boost::detail::winapi::CP_ACP_ :
              ::boost::detail::winapi::CP_OEMCP_;
 
-     int count;
-     if ((count = ::boost::detail::winapi::MultiByteToWideChar(codepage,
+     int count = 0;
+     int size = static_cast<int>(from_end - from);
+     // if size is 0, the function fails
+     if (size != 0 && (count = ::boost::detail::winapi::MultiByteToWideChar(codepage,
              ::boost::detail::winapi::MB_PRECOMPOSED_, from,
-       static_cast<int>(from_end - from), to, static_cast<int>(to_end - to))) == 0)
+       size, to, static_cast<int>(to_end - to))) == 0)
      {
        return error;  // conversion failed
      }
@@ -68,10 +70,12 @@ class windows_file_codecvt
                        ::boost::detail::winapi::CP_ACP_ :
                      ::boost::detail::winapi::CP_OEMCP_;
 
-     int count;
-     if ((count = ::boost::detail::winapi::WideCharToMultiByte(codepage,
+     int count = 0;
+     int size = static_cast<int>(from_end - from);
+     // if size is 0, the function fails
+     if (size != 0 && (count = ::boost::detail::winapi::WideCharToMultiByte(codepage,
                    ::boost::detail::winapi::WC_NO_BEST_FIT_CHARS_, from,
-                  static_cast<int>(from_end - from), to, static_cast<int>(to_end - to), 0, 0)) == 0)
+                  size, to, static_cast<int>(to_end - to), 0, 0)) == 0)
      {
        return error;  // conversion failed
      }

--- a/include/boost/process/locale.hpp
+++ b/include/boost/process/locale.hpp
@@ -170,7 +170,7 @@ inline std::string convert(const std::wstring & st,
                            const ::boost::process::codecvt_type & cvt =
                                 ::boost::process::codecvt())
 {
-    std::string out(st.size() * 2, ' '); //just to be sure
+    std::string out((st.size() + 1) * 2, ' '); //just to be sure
     auto sz = convert(st.c_str(), st.c_str() + st.size(),
                       &out.front(), &out.back(), cvt);
 


### PR DESCRIPTION
I'd like run application with empty working directory, meaning the use of the current working directory.
But i have problem with convert. I tried to fix this.
Here is an example where this did not work.
```
#include <boost/process.hpp>

namespace bp = boost::process;

bp::child shell_cmd(const std::string& cmd, const std::string& dir = std::string())
{
    return bp::child(cmd, bp::start_dir = dir, bp::shell);
}

int main(void)
{
    // check convert for different types of char
    bp::detail::convert("");
    bp::detail::convert(L"");

    shell_cmd("dir").wait();
    return 0;
}
```
Also CreateProcess require nullptr, and not empty string for run application with current working directory. But this is a separate problem.