### PR TITLE
Make empty bp::start_dir as use of the current working directory

### DIFF
--- a/include/boost/process/detail/posix/start_dir.hpp
+++ b/include/boost/process/detail/posix/start_dir.hpp
@@ -26,7 +26,8 @@ struct start_dir_init : handler_base_ext
     template <class PosixExecutor>
     void on_exec_setup(PosixExecutor&) const
     {
-        ::chdir(s_.c_str());
+        if (!s_.empty())
+            ::chdir(s_.c_str());
     }
     const string_type & str() const {return s_;}
 private:

--- a/include/boost/process/detail/windows/start_dir.hpp
+++ b/include/boost/process/detail/windows/start_dir.hpp
@@ -23,7 +23,8 @@ struct start_dir_init : handler_base_ext
     template <class Executor>
     void on_setup(Executor& exec) const
     {
-        exec.work_dir = s_.c_str();
+        if (!s_.empty())
+            exec.work_dir = s_.c_str();
     }
 
     const std::basic_string<Char> &str() const {return s_;}


### PR DESCRIPTION
I'd like run application with empty working directory, meaning the use of the current working directory.
The simple example.
```
#include <boost/process.hpp>

namespace bp = boost::process;

bp::child shell_cmd(const std::string& cmd, const std::string& dir = std::string())
{
    return bp::child(cmd, bp::start_dir = dir);
}

int main(void)
{
    shell_cmd("cmd").wait();
    return 0;
}
```