### PR TITLE
Properly write the output in operator basic_pipe for async_pipe

### DIFF
--- a/include/boost/process/detail/windows/async_pipe.hpp
+++ b/include/boost/process/detail/windows/async_pipe.hpp
@@ -85,7 +85,7 @@ public:
     }
 
     template<class CharT, class Traits = std::char_traits<CharT>>
-    inline explicit operator basic_pipe<CharT, Traits>() const;
+    inline explicit operator basic_pipe<CharT, Traits>();
 
     void cancel()
     {
@@ -334,7 +334,7 @@ async_pipe& async_pipe::operator=(async_pipe && rhs)
 }
 
 template<class CharT, class Traits>
-async_pipe::operator basic_pipe<CharT, Traits>() const
+async_pipe::operator basic_pipe<CharT, Traits>()
 {
     auto proc = ::boost::detail::winapi::GetCurrentProcess();
 
@@ -342,8 +342,8 @@ async_pipe::operator basic_pipe<CharT, Traits>() const
     ::boost::detail::winapi::HANDLE_ sink;
 
     //cannot get the handle from a const object.
-    auto source_in = const_cast<::boost::asio::windows::stream_handle &>(_source).native();
-    auto sink_in   = const_cast<::boost::asio::windows::stream_handle &>(_sink).native();
+    auto source_in = _source.native();
+    auto sink_in   = _sink.native();
 
     if (source == ::boost::detail::winapi::INVALID_HANDLE_VALUE_)
         _source = ::boost::detail::winapi::INVALID_HANDLE_VALUE_;

--- a/include/boost/process/detail/windows/async_pipe.hpp
+++ b/include/boost/process/detail/windows/async_pipe.hpp
@@ -345,16 +345,16 @@ async_pipe::operator basic_pipe<CharT, Traits>()
     auto source_in = _source.native();
     auto sink_in   = _sink.native();
 
-    if (source == ::boost::detail::winapi::INVALID_HANDLE_VALUE_)
-        _source = ::boost::detail::winapi::INVALID_HANDLE_VALUE_;
+    if (source_in == ::boost::detail::winapi::INVALID_HANDLE_VALUE_)
+        source = ::boost::detail::winapi::INVALID_HANDLE_VALUE_;
     else if (!::boost::detail::winapi::DuplicateHandle(
             proc, source_in, proc, &source, 0,
             static_cast<::boost::detail::winapi::BOOL_>(true),
              ::boost::detail::winapi::DUPLICATE_SAME_ACCESS_))
         throw_last_error("Duplicate Pipe Failed");
 
-    if (sink == ::boost::detail::winapi::INVALID_HANDLE_VALUE_)
-        _sink = ::boost::detail::winapi::INVALID_HANDLE_VALUE_;
+    if (sink_in == ::boost::detail::winapi::INVALID_HANDLE_VALUE_)
+        sink = ::boost::detail::winapi::INVALID_HANDLE_VALUE_;
     else if (!::boost::detail::winapi::DuplicateHandle(
             proc, sink_in, proc, &sink, 0,
             static_cast<::boost::detail::winapi::BOOL_>(true),

--- a/include/boost/process/detail/windows/environment.hpp
+++ b/include/boost/process/detail/windows/environment.hpp
@@ -67,8 +67,7 @@ inline auto native_environment_impl<Char>::get(const pointer_type id) -> string_
         if (err == ::boost::detail::winapi::ERROR_ENVVAR_NOT_FOUND_)//well, then we consider that an empty value
             return "";
         else
-            throw process_error("GetEnvironmentVariable() failed",
-                    std::error_code(err, std::system_category()));
+            throw process_error(std::error_code(err, std::system_category()));
     }
 
     if (size == sizeof(buf)) //the return size gives the size without the null, so I know this went wrong


### PR DESCRIPTION
Pretty sure this was backwards? It makes no sense to check
`source` and `sink`, you only declared them four lines ago and
nothing touched them since.
This way, we do something that does make sense: returning an
invalid handle if the handle stored in this object is itself an
invalid handle.