### PR TITLE
Respect WIFSIGNALED in all relevant places

### DIFF
--- a/include/boost/process/detail/posix/wait_for_exit.hpp
+++ b/include/boost/process/detail/posix/wait_for_exit.hpp
@@ -43,10 +43,12 @@ inline void wait(const child_handle &p, int & exit_code, std::error_code &ec) no
     {
         ret = ::waitpid(p.pid, &status, 0);
     } 
-    while (((ret == -1) && (errno == EINTR)) || (ret != -1 && !WIFEXITED(status)));
+    while (((ret == -1) && (errno == EINTR)) || (ret != -1 && !WIFEXITED(status) && !WIFSIGNALED(status)));
     
     if (ret == -1)
         ec = boost::process::detail::get_last_error();
+    else if (WIFSIGNALED(status))
+        ec = std::make_error_code(std::errc::no_such_process);
     else
     {
         ec.clear();
@@ -79,12 +81,14 @@ inline bool wait_for(
             break;
         }
     } 
-    while (((ret == -1) && errno == EINTR)       || 
-           ((ret != -1) && !WIFEXITED(status)));
+    while (((ret == -1) && errno == EINTR)                               ||
+           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status)));
 
 
     if (ret == -1)
         boost::process::detail::throw_last_error("waitpid(2) failed");
+    if (WIFSIGNALED(status))
+        throw process_error(std::error_code(), "process terminated due to receipt of a signal");
      
     exit_code = status;
 
@@ -116,12 +120,14 @@ inline bool wait_for(
             break;
         }
     } 
-    while (((ret == -1) && errno == EINTR)       || 
-           ((ret != -1) && !WIFEXITED(status)));
+    while (((ret == -1) && errno == EINTR)                               ||
+           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status)));
 
 
     if (ret == -1)
         ec = boost::process::detail::get_last_error();
+    else if (WIFSIGNALED(status))
+        ec = std::make_error_code(std::errc::no_such_process);
     else
     {
         ec.clear();
@@ -153,12 +159,14 @@ inline bool wait_until(
             break;
         }
     } 
-    while (((ret == -1) && errno == EINTR)       || 
-           ((ret != -1) && !WIFEXITED(status)));
+    while (((ret == -1) && errno == EINTR)                               ||
+           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status)));
 
 
     if (ret == -1)
         boost::process::detail::throw_last_error("waitpid(2) failed");
+    if (WIFSIGNALED(status))
+        throw process_error(std::error_code(), "process terminated due to receipt of a signal");
 
     exit_code = status;
 
@@ -187,12 +195,14 @@ inline bool wait_until(
             break;
         }
     } 
-    while (((ret == -1) && errno == EINTR)       || 
-           ((ret != -1) && !WIFEXITED(status)));
+    while (((ret == -1) && errno == EINTR)                               ||
+           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status)));
 
 
     if (ret == -1)
         ec = boost::process::detail::get_last_error();
+    else if (WIFSIGNALED(status))
+        ec = std::make_error_code(std::errc::no_such_process);
     else
     {
         ec.clear();

--- a/include/boost/process/detail/posix/wait_group.hpp
+++ b/include/boost/process/detail/posix/wait_group.hpp
@@ -25,9 +25,11 @@ inline void wait(const group_handle &p)
     do
     {
         ret = ::waitpid(-p.grp, &status, 0);
-    } while (((ret == -1) && (errno == EINTR)) || (ret != -1 && !WIFEXITED(status)));
+    } while (((ret == -1) && (errno == EINTR)) || (ret != -1 && !WIFEXITED(status) && !WIFSIGNALED(status)));
     if (ret == -1)
         boost::process::detail::throw_last_error("waitpid(2) failed");
+    if (WIFSIGNALED(status))
+        throw process_error(std::error_code(), "process group terminated due to receipt of a signal");
 }
 
 inline void wait(const group_handle &p, std::error_code &ec) noexcept
@@ -39,10 +41,12 @@ inline void wait(const group_handle &p, std::error_code &ec) noexcept
     {
         ret = ::waitpid(-p.grp, &status, 0);
     } 
-    while (((ret == -1) && (errno == EINTR)) || (ret != -1 && !WIFEXITED(status)));
+    while (((ret == -1) && (errno == EINTR)) || (ret != -1 && !WIFEXITED(status) && !WIFSIGNALED(status)));
     
     if (ret == -1)
         ec = boost::process::detail::get_last_error();
+    else if (WIFSIGNALED(status))
+        ec = std::make_error_code(std::errc::no_such_process);
     else
         ec.clear();
 
@@ -70,13 +74,14 @@ inline bool wait_for(
             break;
         }
     } 
-    while (((ret == -1) && errno == EINTR)       || 
-           ((ret != -1) && !WIFEXITED(status)));
+    while (((ret == -1) && errno == EINTR)                               ||
+           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status)));
 
 
     if (ret == -1)
         boost::process::detail::throw_last_error("waitpid(2) failed");
-     
+    if (WIFSIGNALED(status))
+        throw process_error(std::error_code(), "process group terminated due to receipt of a signal");
 
     return !time_out_occured;
 }
@@ -105,12 +110,14 @@ inline bool wait_for(
             break;
         }
     } 
-    while (((ret == -1) && errno == EINTR)       || 
-           ((ret != -1) && !WIFEXITED(status)));
+    while (((ret == -1) && errno == EINTR)                       ||
+           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status)));
 
 
     if (ret == -1)
         ec = boost::process::detail::get_last_error();
+    else if (WIFSIGNALED(status))
+        ec = std::make_error_code(std::errc::no_such_process);
     else
         ec.clear();
 
@@ -138,12 +145,14 @@ inline bool wait_until(
             break;
         }
     } 
-    while (((ret == -1) && errno == EINTR)       || 
-           ((ret != -1) && !WIFEXITED(status)));
+    while (((ret == -1) && errno == EINTR)                               ||
+           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status)));
 
 
     if (ret == -1)
         boost::process::detail::throw_last_error("waitpid(2) failed");
+    if (WIFSIGNALED(status))
+        throw process_error(std::error_code(), "process group terminated due to receipt of a signal");
 
 
     return !time_out_occured;
@@ -172,12 +181,14 @@ inline bool wait_until(
             break;
         }
     } 
-    while (((ret == -1) && errno == EINTR)       || 
-           ((ret != -1) && !WIFEXITED(status)));
+    while (((ret == -1) && errno == EINTR)                               ||
+           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status)));
 
 
     if (ret == -1)
         ec = boost::process::detail::get_last_error();
+    else if (WIFSIGNALED(status))
+        ec = std::make_error_code(std::errc::no_such_process);
     else
         ec.clear();
 


### PR DESCRIPTION
Was only respected for one `waitpid` call (as pointed out by @egorpugin int [my last PR](https://github.com/boostorg/process/pull/11))