### PR TITLE
Avoid string charset conversion

### DIFF
--- a/include/boost/process/detail/windows/search_path.hpp
+++ b/include/boost/process/detail/windows/search_path.hpp
@@ -65,7 +65,7 @@ inline boost::filesystem::path search_path(
             boost::system::error_code ec;
             bool file = boost::filesystem::is_regular_file(pp, ec);
             if (!ec && file &&
-                ::boost::detail::winapi::sh_get_file_info(pp.string().c_str(), 0, 0, 0, ::boost::detail::winapi::SHGFI_EXETYPE_))
+                ::boost::detail::winapi::sh_get_file_info(pp.native().c_str(), 0, 0, 0, ::boost::detail::winapi::SHGFI_EXETYPE_))
             {
                 return pp;
             }


### PR DESCRIPTION
`boost::filesystem::path::native()` returns a const ref to a std::wstring (on Windows), so this should be better than `boost::filesystem::path::string()` (that does a full conversion using codecvt which might introduce all sorts of problems with paths containing special characters) and `boost::filesystem::path::wstring()` (which does no conversion, but still creates a copy).