### PR TITLE
fix `rdbuf()` implementation on pipe

### DIFF
--- a/include/boost/process/pipe.hpp
+++ b/include/boost/process/pipe.hpp
@@ -262,7 +262,7 @@ public:
     typedef  typename Traits::off_type off_type   ;
 
     ///Get access to the underlying stream_buf
-    basic_pipebuf<CharT, Traits>* rdbuf() const {return _buf;};
+    basic_pipebuf<CharT, Traits>* rdbuf() {return &_buf;};
 
     ///Default constructor.
     basic_ipstream() : std::basic_istream<CharT, Traits>(nullptr)


### PR DESCRIPTION
Ran into this compilation failure.

It seems the only reason it "compiles" is because of shallow template instantiation.

This implies we might need more test coverage :)