### PR TITLE
Fix async_pipe reassignment and child_decl

### DIFF
--- a/include/boost/process/detail/child_decl.hpp
+++ b/include/boost/process/detail/child_decl.hpp
@@ -65,7 +65,8 @@ public:
     child(child && lhs) noexcept
         : _child_handle(std::move(lhs._child_handle)),
           _exit_status(std::move(lhs._exit_status)),
-          _attached (lhs._attached)
+          _attached (lhs._attached),
+          _terminated (lhs._terminated)
     {
         lhs._attached = false;
     }

--- a/include/boost/process/detail/posix/async_pipe.hpp
+++ b/include/boost/process/detail/posix/async_pipe.hpp
@@ -11,6 +11,7 @@
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <system_error>
 #include <string>
+#include <utility>
 
 namespace boost { namespace process { namespace detail { namespace posix {
 
@@ -69,9 +70,9 @@ public:
     ~async_pipe()
     {
         if (_sink .native_handle()  != -1)
-            ::close(_sink.native_handle());
+            _sink.close();
         if (_source.native_handle() != -1)
-            ::close(_source.native_handle());
+            _source.close();
     }
 
     template<class CharT, class Traits = std::char_traits<CharT>>
@@ -264,16 +265,8 @@ async_pipe& async_pipe::operator=(const async_pipe & p)
 
 async_pipe& async_pipe::operator=(async_pipe && lhs)
 {
-    if (_source.native_handle() == -1)
-         ::close(_source.native_handle());
-
-    if (_sink.native_handle()   == -1)
-        ::close(_sink.native_handle());
-
-    _source.assign(lhs._source.native_handle());
-    _sink  .assign(lhs._sink  .native_handle());
-    lhs._source.assign(-1);
-    lhs._sink  .assign(-1);
+    std::swap(_source, lhs._source);
+    std::swap(_sink, lhs._sink);
     return *this;
 }
 

--- a/include/boost/process/detail/posix/async_pipe.hpp
+++ b/include/boost/process/detail/posix/async_pipe.hpp
@@ -70,9 +70,9 @@ public:
     ~async_pipe()
     {
         if (_sink .native_handle()  != -1)
-            _sink.close();
+            ::close(_sink.native_handle());
         if (_source.native_handle() != -1)
-            _source.close();
+            ::close(_source.native_handle());
     }
 
     template<class CharT, class Traits = std::char_traits<CharT>>


### PR DESCRIPTION
async_pipe was throwing exceptions when reassigning new async_pipes. These changes seem to fix that.

Also small fix for the _terminated field for child_decl's move constructor.