### PR TITLE
Fix: [posix] inconsistent exit status when child received signal #136

### DIFF
--- a/include/boost/process/detail/posix/is_running.hpp
+++ b/include/boost/process/detail/posix/is_running.hpp
@@ -17,6 +17,11 @@ namespace boost { namespace process { namespace detail { namespace posix {
 constexpr int still_active = 0x7F;
 static_assert(!WIFEXITED(still_active), "Internal Error");
 
+inline bool is_running(int code)
+{
+    return !WIFEXITED(code) && !WIFSIGNALED(code);
+}
+
 inline bool is_running(const child_handle &p, int & exit_code)
 {
     int status; 
@@ -33,7 +38,7 @@ inline bool is_running(const child_handle &p, int & exit_code)
         return true;
     else //exited
     {
-        if (WIFEXITED(status))
+        if (!is_running(status))
             exit_code = status;
         return false;
     }
@@ -56,16 +61,11 @@ inline bool is_running(const child_handle &p, int & exit_code, std::error_code &
     {
         ec.clear();
         
-        if (WIFEXITED(status))
+        if (!is_running(status))
             exit_code = status;
         
         return false;
     }
-}
-
-inline bool is_running(int code)
-{
-    return !WIFEXITED(code);
 }
 
 inline int eval_exit_status(int code)


### PR DESCRIPTION
Proposed change from #136 