### PR TITLE
Fixed inconsistent posix-wait-handling

### DIFF
--- a/include/boost/process/detail/config.hpp
+++ b/include/boost/process/detail/config.hpp
@@ -82,6 +82,17 @@ inline void throw_last_error()
     throw process_error(get_last_error());
 }
 
+inline void throw_error(const std::error_code& err)
+{
+  if (err)
+    throw process_error(err);
+}
+
+inline void throw_error(const std::error_code& err, const char* location)
+{
+  if (err)
+    throw process_error(err, location);
+}
 
 template<typename Char> constexpr Char null_char();
 template<> constexpr char     null_char<char>     (){return   '\0';}

--- a/include/boost/process/detail/posix/wait_for_exit.hpp
+++ b/include/boost/process/detail/posix/wait_for_exit.hpp
@@ -19,21 +19,6 @@
 
 namespace boost { namespace process { namespace detail { namespace posix {
 
-inline void wait(const child_handle &p, int & exit_code)
-{
-    pid_t ret;
-    int status;
-    do
-    {
-        ret = ::waitpid(p.pid, &status, 0);
-    } while (((ret == -1) && (errno == EINTR)) || (ret != -1 && !WIFEXITED(status) && !WIFSIGNALED(status)));
-    if (ret == -1)
-        boost::process::detail::throw_last_error("waitpid(2) failed");
-    if (WIFSIGNALED(status))
-        throw process_error(std::error_code(), "process terminated due to receipt of a signal");
-     exit_code = status;
-}
-
 inline void wait(const child_handle &p, int & exit_code, std::error_code &ec) noexcept
 {
     pid_t ret;
@@ -44,87 +29,6 @@ inline void wait(const child_handle &p, int & exit_code, std::error_code &ec) no
         ret = ::waitpid(p.pid, &status, 0);
     } 
     while (((ret == -1) && (errno == EINTR)) || (ret != -1 && !WIFEXITED(status) && !WIFSIGNALED(status)));
-    
-    if (ret == -1)
-        ec = boost::process::detail::get_last_error();
-    else
-    {
-        ec.clear();
-        exit_code = status;
-    }
-  
-
-}
-
-template< class Rep, class Period >
-inline bool wait_for(
-        const child_handle &p,
-        int & exit_code,
-        const std::chrono::duration<Rep, Period>& rel_time)
-{
-
-    pid_t ret;
-    int status;
-
-    auto start = std::chrono::system_clock::now();
-    auto time_out = start + rel_time;
-
-    bool timed_out;
-    do
-    {
-        ret = ::waitpid(p.pid, &status, WNOHANG);
-        if (ret == 0)
-        {
-            timed_out = std::chrono::system_clock::now() >= time_out;    
-            if (timed_out)
-                return false;
-        }
-    } 
-    while ((ret == 0) ||
-           ((ret == -1) && errno == EINTR) ||
-           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status)));
-
-    if (ret == -1)
-        boost::process::detail::throw_last_error("waitpid(2) failed");
-
-    exit_code = status;
-
-    return true;
-}
-
-
-template< class Rep, class Period >
-inline bool wait_for(
-        const child_handle &p,
-        int & exit_code,
-        const std::chrono::duration<Rep, Period>& rel_time,
-        std::error_code & ec) noexcept
-{
-
-    pid_t ret;
-    int status;
-
-    auto start = std::chrono::system_clock::now();
-    auto time_out = start + rel_time;
-    bool timed_out;
-
-    do
-    {
-        ret = ::waitpid(p.pid, &status, WNOHANG);
-        if (ret == 0)
-        {
-            timed_out = std::chrono::system_clock::now() >= time_out;    
-            if (timed_out)
-                return false;
-        }
-    } 
-    while ((ret == 0) ||
-          (((ret == -1) && errno == EINTR) ||
-           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status))));
-
-
-    if (timed_out && (ret == -1))
-    	return false;
 
     if (ret == -1)
         ec = boost::process::detail::get_last_error();
@@ -133,48 +37,14 @@ inline bool wait_for(
         ec.clear();
         exit_code = status;
     }
-
-    return true;
 }
 
-
-
-template< class Clock, class Duration >
-inline bool wait_until(
-        const child_handle &p,
-        int & exit_code,
-        const std::chrono::time_point<Clock, Duration>& time_out)
+inline void wait(const child_handle &p, int & exit_code) noexcept
 {
-
-    pid_t ret;
-    int status;
-
-    bool timed_out;
-    do
-    {
-        ret = ::waitpid(p.pid, &status, WNOHANG);
-        if (ret == 0)
-        {
-            timed_out = std::chrono::system_clock::now() >= time_out;    
-            if (timed_out)
-                return false;
-        }
-    }
-    while ((ret == 0) ||
-          (((ret == -1) && errno == EINTR) ||
-           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status))));
-
-
-    if (timed_out && !WIFEXITED(status))
-    	return false;
-
-    if (ret == -1)
-        boost::process::detail::throw_last_error("waitpid(2) failed");
-    exit_code = status;
-
-    return true;
+    std::error_code ec;
+    wait(p, exit_code, ec);
+    boost::process::detail::throw_error(ec, "wait");
 }
-
 
 template< class Clock, class Duration >
 inline bool wait_until(
@@ -183,7 +53,6 @@ inline bool wait_until(
         const std::chrono::time_point<Clock, Duration>& time_out,
         std::error_code & ec) noexcept
 {
-
     pid_t ret;
     int status;
 
@@ -194,19 +63,14 @@ inline bool wait_until(
         ret = ::waitpid(p.pid, &status, WNOHANG);
         if (ret == 0)
         {
-            timed_out = std::chrono::system_clock::now() >= time_out;    
+            timed_out = Clock::now() >= time_out;
             if (timed_out)
                 return false;
         }
-    } 
+    }
     while ((ret == 0) ||
           (((ret == -1) && errno == EINTR) ||
            ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status))));
-
-
-
-    if (timed_out && !WIFEXITED(status))
-    	return false;
 
     if (ret == -1)
         ec = boost::process::detail::get_last_error();
@@ -217,6 +81,40 @@ inline bool wait_until(
     }
 
     return true;
+}
+
+template< class Clock, class Duration >
+inline bool wait_until(
+        const child_handle &p,
+        int & exit_code,
+        const std::chrono::time_point<Clock, Duration>& time_out) noexcept
+{
+    std::error_code ec;
+    bool b = wait_until(p, exit_code, time_out, ec);
+    boost::process::detail::throw_error(ec, "wait_until");
+    return b;
+}
+
+template< class Rep, class Period >
+inline bool wait_for(
+        const child_handle &p,
+        int & exit_code,
+        const std::chrono::duration<Rep, Period>& rel_time,
+        std::error_code & ec) noexcept
+{
+    return wait_until(p, exit_code, std::chrono::steady_clock::now() + rel_time, ec);
+}
+
+template< class Rep, class Period >
+inline bool wait_for(
+        const child_handle &p,
+        int & exit_code,
+        const std::chrono::duration<Rep, Period>& rel_time) noexcept
+{
+    std::error_code ec;
+    bool b = wait_for(p, exit_code, rel_time, ec);
+    boost::process::detail::throw_error(ec, "wait_for");
+    return b;
 }
 
 }}}}


### PR DESCRIPTION
This commit addresses point 2 in #116 
All wait-methods should behave the same way.
Fixes:
- Removed throwing process_error in case the child received a signal
- Added general throw_error method, which can be used to avoid code duplication (basically the same way Boost ASIO does it)
- Removed system_clock from wait_until and replaced it with template-parameter Clock
- wait_for now uses the monotonic steady_clock instead of system_clock
- Removed duplicated code