### PR TITLE
Fix: Inconsistent behaviour in various overloaded functions/methods #139

### DIFF
--- a/include/boost/process/detail/child_decl.hpp
+++ b/include/boost/process/detail/child_decl.hpp
@@ -103,62 +103,42 @@ public:
 
     bool running()
     {
-        if (valid() && !_exited())
-        {
-            int code = -1;
-            auto res = boost::process::detail::api::is_running(_child_handle, code);
-            if (!res && !_exited())
-                _exit_status->store(code);
-
-            return res;
-        }
-        return false;
+        std::error_code ec;
+        bool b = running(ec);
+        boost::process::detail::throw_error(ec, "running error");
+        return b;
     }
 
     void terminate()
     {
-        if (valid() && running())
-            boost::process::detail::api::terminate(_child_handle);
-
-        _terminated = true;
+        std::error_code ec;
+        terminate(ec);
+        boost::process::detail::throw_error(ec, "terminate error");
     }
 
     void wait()
     {
-        if (!_exited() && valid())
-        {
-            int exit_code = 0;
-            boost::process::detail::api::wait(_child_handle, exit_code);
-            _exit_status->store(exit_code);
-        }
+        std::error_code ec;
+        wait(ec);
+        boost::process::detail::throw_error(ec, "wait error");
     }
 
     template< class Rep, class Period >
-    bool wait_for  (const std::chrono::duration<Rep, Period>& rel_time)
+    bool wait_for (const std::chrono::duration<Rep, Period>& rel_time)
     {
-        if (!_exited())
-        {
-            int exit_code = 0;
-            auto b = boost::process::detail::api::wait_for(_child_handle, exit_code, rel_time);
-            if (!b)
-                return false;
-            _exit_status->store(exit_code);
-        }
-        return true;
+        std::error_code ec;
+        bool b = wait_for(rel_time, ec);
+        boost::process::detail::throw_error(ec, "wait_for error");
+        return b;
     }
 
     template< class Clock, class Duration >
     bool wait_until(const std::chrono::time_point<Clock, Duration>& timeout_time )
     {
-        if (!_exited())
-        {
-            int exit_code = 0;
-            auto b = boost::process::detail::api::wait_until(_child_handle, exit_code, timeout_time);
-            if (!b)
-                return false;
-            _exit_status->store(exit_code);
-        }
-        return true;
+        std::error_code ec;
+        bool b = wait_until(timeout_time, ec);
+        boost::process::detail::throw_error(ec, "wait_until error");
+        return b;
     }
 
     bool running(std::error_code & ec) noexcept
@@ -194,17 +174,9 @@ public:
     }
 
     template< class Rep, class Period >
-    bool wait_for  (const std::chrono::duration<Rep, Period>& rel_time, std::error_code & ec) noexcept
+    bool wait_for (const std::chrono::duration<Rep, Period>& rel_time, std::error_code & ec) noexcept
     {
-        if (!_exited())
-        {
-            int exit_code = 0;
-            auto b = boost::process::detail::api::wait_for(_child_handle, exit_code, rel_time, ec);
-            if (!b)
-                return false;
-            _exit_status->store(exit_code);
-        }
-        return true;
+        return wait_until(std::chrono::steady_clock::now() + rel_time, ec);
     }
 
     template< class Clock, class Duration >

--- a/include/boost/process/detail/config.hpp
+++ b/include/boost/process/detail/config.hpp
@@ -82,16 +82,16 @@ inline void throw_last_error()
     throw process_error(get_last_error());
 }
 
-inline void throw_error(const std::error_code& err)
+inline void throw_error(const std::error_code& ec)
 {
-  if (err)
-    throw process_error(err);
+    if (ec)
+        throw process_error(ec);
 }
 
-inline void throw_error(const std::error_code& err, const char* location)
+inline void throw_error(const std::error_code& ec, const char* msg)
 {
-  if (err)
-    throw process_error(err, location);
+    if (ec)
+        throw process_error(ec, msg);
 }
 
 template<typename Char> constexpr Char null_char();

--- a/include/boost/process/detail/posix/group_handle.hpp
+++ b/include/boost/process/detail/posix/group_handle.hpp
@@ -6,13 +6,12 @@
 #ifndef BOOST_PROCESS_DETAIL_POSIX_GROUP_HPP_
 #define BOOST_PROCESS_DETAIL_POSIX_GROUP_HPP_
 
+#include <boost/process/detail/config.hpp>
 #include <boost/process/detail/posix/child_handle.hpp>
 #include <system_error>
 #include <unistd.h>
 
 namespace boost { namespace process { namespace detail { namespace posix {
-
-
 
 struct group_handle
 {
@@ -26,7 +25,6 @@ struct group_handle
     {
     }
 
-
      group_handle() = default;
 
     ~group_handle() = default;
@@ -38,7 +36,6 @@ struct group_handle
     group_handle &operator=(const group_handle & c) = delete;
     group_handle &operator=(group_handle && c)
     {
-
         grp = c.grp;
         c.grp = -1;
         return *this;
@@ -62,22 +59,13 @@ struct group_handle
     bool has(handle_t proc, std::error_code & ec) noexcept
     {
         return ::getpgid(proc) == grp;
-
     }
 
     bool valid() const
     {
         return grp != -1;
     }
-
 };
-
-inline void terminate(group_handle &p)
-{
-    if (::killpg(p.grp, SIGKILL) == -1)
-        boost::process::detail::throw_last_error("killpg(2) failed");
-    p.grp = -1;
-}
 
 inline  void terminate(group_handle &p, std::error_code &ec) noexcept
 {
@@ -89,15 +77,18 @@ inline  void terminate(group_handle &p, std::error_code &ec) noexcept
     p.grp = -1;
 }
 
+inline void terminate(group_handle &p)
+{
+    std::error_code ec;
+    terminate(p, ec);
+    boost::process::detail::throw_error(ec, "killpg(2) failed in terminate");
+}
 
 inline bool in_group()
 {
     return true;
 }
 
-
-
 }}}}
-
 
 #endif /* BOOST_PROCESS_DETAIL_WINDOWS_GROUP_HPP_ */

--- a/include/boost/process/detail/posix/terminate.hpp
+++ b/include/boost/process/detail/posix/terminate.hpp
@@ -19,15 +19,6 @@
 
 namespace boost { namespace process { namespace detail { namespace posix {
 
-
-inline void terminate(const child_handle &p)
-{
-    if (::kill(p.pid, SIGKILL) == -1)
-        boost::process::detail::throw_last_error("kill(2) failed");
-    int status;
-    ::waitpid(p.pid, &status, 0); //just to clean it up
-}
-
 inline void terminate(const child_handle &p, std::error_code &ec) noexcept
 {
     if (::kill(p.pid, SIGKILL) == -1)
@@ -37,6 +28,13 @@ inline void terminate(const child_handle &p, std::error_code &ec) noexcept
 
     int status;
     ::waitpid(p.pid, &status, 0); //just to clean it up
+}
+
+inline void terminate(const child_handle &p)
+{
+    std::error_code ec;
+    terminate(p, ec);
+    boost::process::detail::throw_error(ec, "kill(2) failed");
 }
 
 }}}}

--- a/include/boost/process/detail/posix/wait_for_exit.hpp
+++ b/include/boost/process/detail/posix/wait_for_exit.hpp
@@ -43,7 +43,7 @@ inline void wait(const child_handle &p, int & exit_code) noexcept
 {
     std::error_code ec;
     wait(p, exit_code, ec);
-    boost::process::detail::throw_error(ec, "wait");
+    boost::process::detail::throw_error(ec, "waitpid(2) failed in wait");
 }
 
 template< class Clock, class Duration >
@@ -91,7 +91,7 @@ inline bool wait_until(
 {
     std::error_code ec;
     bool b = wait_until(p, exit_code, time_out, ec);
-    boost::process::detail::throw_error(ec, "wait_until");
+    boost::process::detail::throw_error(ec, "waitpid(2) failed in wait_until");
     return b;
 }
 
@@ -113,7 +113,7 @@ inline bool wait_for(
 {
     std::error_code ec;
     bool b = wait_for(p, exit_code, rel_time, ec);
-    boost::process::detail::throw_error(ec, "wait_for");
+    boost::process::detail::throw_error(ec, "waitpid(2) failed in wait_for");
     return b;
 }
 

--- a/include/boost/process/detail/posix/wait_group.hpp
+++ b/include/boost/process/detail/posix/wait_group.hpp
@@ -12,25 +12,12 @@
 
 #include <boost/process/detail/config.hpp>
 #include <boost/process/detail/posix/group_handle.hpp>
+#include <chrono>
 #include <system_error>
 #include <sys/types.h>
 #include <sys/wait.h>
 
 namespace boost { namespace process { namespace detail { namespace posix {
-
-inline void wait(const group_handle &p)
-{
-    pid_t ret;
-    int status;
-    do
-    {
-        ret = ::waitpid(-p.grp, &status, 0);
-    } while (((ret == -1) && (errno == EINTR)) || (ret != -1 && !WIFEXITED(status) && !WIFSIGNALED(status)));
-    if (ret == -1)
-        boost::process::detail::throw_last_error("waitpid(2) failed");
-    if (WIFSIGNALED(status))
-        throw process_error(std::error_code(), "process group terminated due to receipt of a signal");
-}
 
 inline void wait(const group_handle &p, std::error_code &ec) noexcept
 {
@@ -42,50 +29,63 @@ inline void wait(const group_handle &p, std::error_code &ec) noexcept
         ret = ::waitpid(-p.grp, &status, 0);
     } 
     while (((ret == -1) && (errno == EINTR)) || (ret != -1 && !WIFEXITED(status) && !WIFSIGNALED(status)));
-    
+
     if (ret == -1)
         ec = boost::process::detail::get_last_error();
-    else if (WIFSIGNALED(status))
-        ec = std::make_error_code(std::errc::no_such_process);
     else
         ec.clear();
-
 }
 
-template< class Rep, class Period >
-inline bool wait_for(
-        const group_handle &p,
-        const std::chrono::duration<Rep, Period>& rel_time)
+inline void wait(const group_handle &p) noexcept
 {
+    std::error_code ec;
+    wait(p, ec);
+    boost::process::detail::throw_error(ec, "waitpid(2) failed in wait");
+}
 
+template< class Clock, class Duration >
+inline bool wait_until(
+        const group_handle &p,
+        const std::chrono::time_point<Clock, Duration>& time_out,
+        std::error_code & ec) noexcept
+{
     pid_t ret;
     int status;
 
-    auto start = std::chrono::system_clock::now();
-    auto time_out = start + rel_time;
+    bool timed_out;
 
-    bool time_out_occured = false;
     do
     {
-        ret = ::waitpid(-p.grp, &status, WUNTRACED | WNOHANG);
-        if (std::chrono::system_clock::now() >= time_out)
+        ret = ::waitpid(-p.grp, &status, WNOHANG);
+        if (ret == 0)
         {
-            time_out_occured = true;
-            break;
+            timed_out = Clock::now() >= time_out;
+            if (timed_out)
+                return false;
         }
-    } 
-    while (((ret == -1) && errno == EINTR)                               ||
-           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status)));
-
+    }
+    while ((ret == 0) ||
+          (((ret == -1) && errno == EINTR) ||
+           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status))));
 
     if (ret == -1)
-        boost::process::detail::throw_last_error("waitpid(2) failed");
-    if (WIFSIGNALED(status))
-        throw process_error(std::error_code(), "process group terminated due to receipt of a signal");
+        ec = boost::process::detail::get_last_error();
+    else
+        ec.clear();
 
-    return !time_out_occured;
+    return true;
 }
 
+template< class Clock, class Duration >
+inline bool wait_until(
+        const group_handle &p,
+        const std::chrono::time_point<Clock, Duration>& time_out) noexcept
+{
+    std::error_code ec;
+    bool b = wait_until(p, time_out, ec);
+    boost::process::detail::throw_error(ec, "waitpid(2) failed in wait_until");
+    return b;
+}
 
 template< class Rep, class Period >
 inline bool wait_for(
@@ -93,104 +93,18 @@ inline bool wait_for(
         const std::chrono::duration<Rep, Period>& rel_time,
         std::error_code & ec) noexcept
 {
-
-    pid_t ret;
-    int status;
-
-    auto start = std::chrono::system_clock::now();
-    auto time_out = start + rel_time;
-
-    bool time_out_occured = false;
-    do
-    {
-        ret = ::waitpid(-p.grp, &status, WUNTRACED | WNOHANG);
-        if (std::chrono::system_clock::now() >= time_out)
-        {
-            time_out_occured = true;
-            break;
-        }
-    } 
-    while (((ret == -1) && errno == EINTR)                       ||
-           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status)));
-
-
-    if (ret == -1)
-        ec = boost::process::detail::get_last_error();
-    else if (WIFSIGNALED(status))
-        ec = std::make_error_code(std::errc::no_such_process);
-    else
-        ec.clear();
-
-    return !time_out_occured;
+    return wait_until(p, std::chrono::steady_clock::now() + rel_time, ec);
 }
 
-
-
 template< class Rep, class Period >
-inline bool wait_until(
+inline bool wait_for(
         const group_handle &p,
-        const std::chrono::duration<Rep, Period>& time_out)
+        const std::chrono::duration<Rep, Period>& rel_time) noexcept
 {
-
-    pid_t ret;
-    int status;
-
-    bool time_out_occured = false;
-    do
-    {
-        ret = ::waitpid(-p.grp, &status, WUNTRACED | WNOHANG);
-        if (std::chrono::system_clock::now() >= time_out)
-        {
-            time_out_occured = true;
-            break;
-        }
-    } 
-    while (((ret == -1) && errno == EINTR)                               ||
-           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status)));
-
-
-    if (ret == -1)
-        boost::process::detail::throw_last_error("waitpid(2) failed");
-    if (WIFSIGNALED(status))
-        throw process_error(std::error_code(), "process group terminated due to receipt of a signal");
-
-
-    return !time_out_occured;
-}
-
-
-template< class Rep, class Period >
-inline bool wait_until(
-        const group_handle &p,
-        const std::chrono::duration<Rep, Period>& time_out,
-        std::error_code & ec) noexcept
-{
-
-    pid_t ret;
-    int status;
-
-    bool time_out_occured = false;
-    do
-    {
-        ret = ::waitpid(-p.grp, &status, WUNTRACED | WNOHANG);
-        if (std::chrono::system_clock::now() >= time_out)
-        {
-            time_out_occured = true;
-            break;
-        }
-    } 
-    while (((ret == -1) && errno == EINTR)                               ||
-           ((ret != -1) && !WIFEXITED(status) && !WIFSIGNALED(status)));
-
-
-    if (ret == -1)
-        ec = boost::process::detail::get_last_error();
-    else if (WIFSIGNALED(status))
-        ec = std::make_error_code(std::errc::no_such_process);
-    else
-        ec.clear();
-
-    return !time_out_occured;
+    std::error_code ec;
+    bool b = wait_for(p, rel_time, ec);
+    boost::process::detail::throw_error(ec, "waitpid(2) failed in wait_for");
+    return b;
 }
 
 }}}}

--- a/include/boost/process/detail/windows/is_running.hpp
+++ b/include/boost/process/detail/windows/is_running.hpp
@@ -18,22 +18,6 @@ constexpr static ::boost::winapi::DWORD_ still_active = 259;
 
 struct child_handle;
 
-inline bool is_running(const child_handle &p, int & exit_code)
-{
-    ::boost::winapi::DWORD_ code;
-    //single value, not needed in the winapi.
-    if (!::boost::winapi::GetExitCodeProcess(p.process_handle(), &code))
-        ::boost::process::detail::throw_last_error("GetExitCodeProcess() failed");
-
-    if (code == still_active)
-        return true;
-    else
-    {
-        exit_code = code;
-        return false;
-    }    
-}
-
 inline bool is_running(const child_handle &p, int & exit_code, std::error_code &ec) noexcept
 {
     ::boost::winapi::DWORD_ code;
@@ -49,7 +33,15 @@ inline bool is_running(const child_handle &p, int & exit_code, std::error_code &
     {
         exit_code = code;
         return false;
-    }    
+    }
+}
+
+inline bool is_running(const child_handle &p, int & exit_code)
+{
+    std::error_code ec;
+    bool b = is_running(p, exit_code, ec);
+    boost::process::detail::throw_error(ec, "GetExitCodeProcess() failed in is_running");
+    return b;
 }
 
 inline bool is_running(int code)

--- a/include/boost/process/detail/windows/terminate.hpp
+++ b/include/boost/process/detail/windows/terminate.hpp
@@ -20,15 +20,6 @@ namespace boost { namespace process { namespace detail { namespace windows {
 
 struct child_handle;
 
-inline void terminate(child_handle &p)
-{
-    if (!::boost::winapi::TerminateProcess(p.process_handle(), EXIT_FAILURE))
-        boost::process::detail::throw_last_error("TerminateProcess() failed");
-
-    ::boost::winapi::CloseHandle(p.proc_info.hProcess);
-    p.proc_info.hProcess = ::boost::winapi::INVALID_HANDLE_VALUE_;
-}
-
 inline void terminate(child_handle &p, std::error_code &ec) noexcept
 {
     if (!::boost::winapi::TerminateProcess(p.process_handle(), EXIT_FAILURE))
@@ -41,8 +32,12 @@ inline void terminate(child_handle &p, std::error_code &ec) noexcept
     }
 }
 
-
-
+inline void terminate(child_handle &p)
+{
+    std::error_code ec;
+    terminate(p, ec);
+    boost::process::detail::throw_error(ec, "TerminateProcess() failed in terminate");
+}
 
 }}}}
 

--- a/include/boost/process/detail/windows/wait_for_exit.hpp
+++ b/include/boost/process/detail/windows/wait_for_exit.hpp
@@ -20,21 +20,6 @@
 
 namespace boost { namespace process { namespace detail { namespace windows {
 
-inline void wait(child_handle &p, int & exit_code)
-{
-    if (::boost::winapi::WaitForSingleObject(p.process_handle(),
-        ::boost::winapi::infinite) == ::boost::winapi::wait_failed)
-            throw_last_error("WaitForSingleObject() failed");
-
-    ::boost::winapi::DWORD_ _exit_code;
-    if (!::boost::winapi::GetExitCodeProcess(p.process_handle(), &_exit_code))
-        throw_last_error("GetExitCodeProcess() failed");
-
-    ::boost::winapi::CloseHandle(p.proc_info.hProcess);
-    p.proc_info.hProcess = ::boost::winapi::INVALID_HANDLE_VALUE_;
-    exit_code = static_cast<int>(_exit_code);
-}
-
 inline void wait(child_handle &p, int & exit_code, std::error_code &ec) noexcept
 {
     ::boost::winapi::DWORD_ _exit_code = 1;
@@ -56,103 +41,12 @@ inline void wait(child_handle &p, int & exit_code, std::error_code &ec) noexcept
     exit_code = static_cast<int>(_exit_code);
 }
 
-
-template< class Rep, class Period >
-inline bool wait_for(
-        child_handle &p,
-        int & exit_code,
-        const std::chrono::duration<Rep, Period>& rel_time)
+inline void wait(child_handle &p, int & exit_code)
 {
-
-    std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(rel_time);
-
-    ::boost::winapi::DWORD_ wait_code;
-    wait_code = ::boost::winapi::WaitForSingleObject(p.process_handle(),
-                   static_cast<::boost::winapi::DWORD_>(ms.count()));
-    if (wait_code == ::boost::winapi::wait_failed)
-        throw_last_error("WaitForSingleObject() failed");
-    else if (wait_code == ::boost::winapi::wait_timeout)
-        return false; //
-
-    ::boost::winapi::DWORD_ _exit_code;
-    if (!::boost::winapi::GetExitCodeProcess(p.process_handle(), &_exit_code))
-        throw_last_error("GetExitCodeProcess() failed");
-
-    exit_code = static_cast<int>(_exit_code);
-    ::boost::winapi::CloseHandle(p.proc_info.hProcess);
-    p.proc_info.hProcess = ::boost::winapi::INVALID_HANDLE_VALUE_;
-    return true;
+    std::error_code ec;
+    wait(p, exit_code, ec);
+    boost::process::detail::throw_error(ec, "wait error");
 }
-
-
-template< class Rep, class Period >
-inline bool wait_for(
-        child_handle &p,
-        int & exit_code,
-        const std::chrono::duration<Rep, Period>& rel_time,
-        std::error_code &ec) noexcept
-{
-
-    std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(rel_time);
-
-
-    ::boost::winapi::DWORD_ wait_code;
-    wait_code = ::boost::winapi::WaitForSingleObject(p.process_handle(),
-                     static_cast<::boost::winapi::DWORD_>(ms.count()));
-    if (wait_code == ::boost::winapi::wait_failed)
-        ec = std::error_code(
-            ::boost::winapi::GetLastError(),
-            std::system_category());
-    else if (wait_code == ::boost::winapi::wait_timeout)
-        return false; //
-
-    ::boost::winapi::DWORD_ _exit_code = 1;
-    if (!::boost::winapi::GetExitCodeProcess(p.process_handle(), &_exit_code))
-    {
-        ec = std::error_code(
-            ::boost::winapi::GetLastError(),
-            std::system_category());
-        return false;
-    }
-    else
-        ec.clear();
-
-    exit_code = static_cast<int>(_exit_code);
-    ::boost::winapi::CloseHandle(p.proc_info.hProcess);
-    p.proc_info.hProcess = ::boost::winapi::INVALID_HANDLE_VALUE_;
-    return true;
-;
-}
-
-template< class Clock, class Duration >
-inline bool wait_until(
-        child_handle &p,
-        int & exit_code,
-        const std::chrono::time_point<Clock, Duration>& timeout_time)
-{
-    std::chrono::milliseconds ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(
-                    timeout_time - std::chrono::system_clock::now());
-
-    ::boost::winapi::DWORD_ wait_code;
-    wait_code = ::boost::winapi::WaitForSingleObject(p.process_handle(),
-                    static_cast<::boost::winapi::DWORD_>(ms.count()));
-
-    if (wait_code == ::boost::winapi::wait_failed)
-        throw_last_error("WaitForSingleObject() failed");
-    else if (wait_code == ::boost::winapi::wait_timeout)
-        return false;
-
-    ::boost::winapi::DWORD_ _exit_code;
-    if (!::boost::winapi::GetExitCodeProcess(p.process_handle(), &_exit_code))
-        throw_last_error("GetExitCodeProcess() failed");
-
-    exit_code = static_cast<int>(_exit_code);
-    ::boost::winapi::CloseHandle(p.proc_info.hProcess);
-    p.proc_info.hProcess = ::boost::winapi::INVALID_HANDLE_VALUE_;
-    return true;
-}
-
 
 template< class Clock, class Duration >
 inline bool wait_until(
@@ -163,7 +57,7 @@ inline bool wait_until(
 {
     std::chrono::milliseconds ms =
             std::chrono::duration_cast<std::chrono::milliseconds>(
-                    timeout_time - std::chrono::system_clock::now());
+                    timeout_time - Clock::now());
 
     ::boost::winapi::DWORD_ wait_code;
     wait_code = ::boost::winapi::WaitForSingleObject(p.process_handle(),
@@ -174,7 +68,7 @@ inline bool wait_until(
             ::boost::winapi::GetLastError(),
             std::system_category());
     else if (wait_code == ::boost::winapi::wait_timeout)
-    	return false;
+        return false;
 
     ::boost::winapi::DWORD_ _exit_code;
     if (!::boost::winapi::GetExitCodeProcess(p.process_handle(), &_exit_code))
@@ -188,9 +82,41 @@ inline bool wait_until(
     ::boost::winapi::CloseHandle(p.proc_info.hProcess);
     p.proc_info.hProcess = ::boost::winapi::INVALID_HANDLE_VALUE_;
     return true;
-;
 }
 
+template< class Clock, class Duration >
+inline bool wait_until(
+        child_handle &p,
+        int & exit_code,
+        const std::chrono::time_point<Clock, Duration>& timeout_time)
+{
+    std::error_code ec;
+    bool b = wait_until(p, exit_code, timeout_time, ec);
+    boost::process::detail::throw_error(ec, "wait_until error");
+    return b;
+}
+
+template< class Rep, class Period >
+inline bool wait_for(
+        child_handle &p,
+        int & exit_code,
+        const std::chrono::duration<Rep, Period>& rel_time,
+        std::error_code &ec) noexcept
+{
+    return wait_until(p, exit_code, std::chrono::steady_clock::now() + rel_time, ec);
+}
+
+template< class Rep, class Period >
+inline bool wait_for(
+        child_handle &p,
+        int & exit_code,
+        const std::chrono::duration<Rep, Period>& rel_time)
+{
+    std::error_code ec;
+    bool b = wait_for(p, exit_code, rel_time, ec);
+    boost::process::detail::throw_error(ec, "wait_for error");
+    return b;
+}
 
 }}}}
 

--- a/include/boost/process/detail/windows/wait_group.hpp
+++ b/include/boost/process/detail/windows/wait_group.hpp
@@ -9,19 +9,11 @@
 #include <boost/process/detail/config.hpp>
 #include <boost/winapi/jobs.hpp>
 #include <boost/winapi/wait.hpp>
-
+#include <chrono>
 
 namespace boost { namespace process { namespace detail { namespace windows {
 
 struct group_handle;
-
-inline void wait(const group_handle &p)
-{
-    if (::boost::winapi::WaitForSingleObject(p.handle(),
-        ::boost::winapi::infinite) == ::boost::winapi::wait_failed)
-            throw_last_error("WaitForSingleObject() failed");
-
-}
 
 inline void wait(const group_handle &p, std::error_code &ec)
 {
@@ -30,38 +22,26 @@ inline void wait(const group_handle &p, std::error_code &ec)
             ec = get_last_error();
 }
 
-
-template< class Rep, class Period >
-inline bool wait_for(
-        const group_handle &p,
-        const std::chrono::duration<Rep, Period>& rel_time)
+inline void wait(const group_handle &p)
 {
-
-    std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(rel_time);
-
-    ::boost::winapi::DWORD_ wait_code;
-    wait_code = ::boost::winapi::WaitForSingleObject(p.handle(), ms.count());
-    if (wait_code == ::boost::winapi::wait_failed)
-        throw_last_error("WaitForSingleObject() failed");
-    else if (wait_code == ::boost::winapi::wait_timeout)
-        return false; //
-
-    return true;
+    std::error_code ec;
+    wait(p, ec);
+    boost::process::detail::throw_error(ec, "wait error");
 }
 
-
-template< class Rep, class Period >
-inline bool wait_for(
+template< class Clock, class Duration >
+inline bool wait_until(
         const group_handle &p,
-        const std::chrono::duration<Rep, Period>& rel_time,
+        const std::chrono::time_point<Clock, Duration>& timeout_time,
         std::error_code &ec)
 {
-
-    std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(rel_time);
-
+    std::chrono::milliseconds ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                    timeout_time - Clock::now());
 
     ::boost::winapi::DWORD_ wait_code;
     wait_code = ::boost::winapi::WaitForSingleObject(p.handle(), ms.count());
+
     if (wait_code == ::boost::winapi::wait_failed)
         ec = get_last_error();
 
@@ -76,44 +56,30 @@ inline bool wait_until(
         const group_handle &p,
         const std::chrono::time_point<Clock, Duration>& timeout_time)
 {
-    std::chrono::milliseconds ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(
-                    timeout_time - std::chrono::system_clock::now());
-
-    ::boost::winapi::DWORD_ wait_code;
-    wait_code = ::boost::winapi::WaitForSingleObject(p.handle(), ms.count());
-
-    if (wait_code == ::boost::winapi::wait_failed)
-        throw_last_error("WaitForSingleObject() failed");
-
-    else if (wait_code == ::boost::winapi::wait_timeout)
-        return false; //
-
-    return true;
+    std::error_code ec;
+    bool b = wait_until(p, timeout_time, ec);
+    boost::process::detail::throw_error(ec, "wait_until error");
+    return b;
 }
 
-
-template< class Clock, class Duration >
-inline bool wait_until(
+template< class Rep, class Period >
+inline bool wait_for(
         const group_handle &p,
-        const std::chrono::time_point<Clock, Duration>& timeout_time,
+        const std::chrono::duration<Rep, Period>& rel_time,
         std::error_code &ec)
 {
-    std::chrono::milliseconds ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(
-                    timeout_time - std::chrono::system_clock::now());
+    return wait_until(p, std::chrono::steady_clock::now() + rel_time, ec);
+}
 
-    ::boost::winapi::DWORD_ wait_code;
-    wait_code = ::boost::winapi::WaitForSingleObject(p.handle(), ms.count());
-
-    if (wait_code == ::boost::winapi::wait_failed)
-        ec = get_last_error();
-
-    else if (wait_code == ::boost::winapi::wait_timeout)
-        return false; //
-
-    return true;
-;
+template< class Rep, class Period >
+inline bool wait_for(
+        const group_handle &p,
+        const std::chrono::duration<Rep, Period>& rel_time)
+{
+    std::error_code ec;
+    bool b = wait_for(p, rel_time, ec);
+    boost::process::detail::throw_error(ec, "wait_for error");
+    return b;
 }
 
 }}}}


### PR DESCRIPTION
Removed duplicated code in overloaded functions.
Replaced system_clock with steady_clock.
[posix] Changed the wait_until-loop for groups to be consistent with the one for childs