### PR TITLE
Fix search_path not to return directories on POSIX

### DIFF
--- a/include/boost/process/detail/posix/search_path.hpp
+++ b/include/boost/process/detail/posix/search_path.hpp
@@ -27,7 +27,9 @@ inline boost::filesystem::path search_path(
     for (const boost::filesystem::path & pp : path)
     {
         auto p = pp / filename;
-        if (!::access(p.c_str(), X_OK))
+        boost::system::error_code ec;
+        bool file = boost::filesystem::is_regular_file(p, ec);
+        if (!ec && file && ::access(p.c_str(), X_OK) == 0)
             return p;
     }
     return "";


### PR DESCRIPTION
On POSIX, `search_path` can return a directory. Given `PATH=/usr/bin:/bin`, searching for `foo` may return a directory `/usr/bin/foo/` (with file mode +x), shadowing an actual executable `/bin/foo`. This is not the behaviour on Windows, as that detail function checks that it is a regular file. It is also not the behaviour of the Unix shell.

This patch checks that the file is a regular file, in the same way as on Windows, fixing the discrepancy.