### PR TITLE
Only reap children we are watching for when handling SIGCHLD

### DIFF
--- a/doc/extend.qbk
+++ b/doc/extend.qbk
@@ -108,8 +108,6 @@ struct async_foo : __handler__, __require_io_service__
     }
 };
 ```
-[caution All async_handlers use one signal(SIGCHLD) on posix, which is only guaranteed to work when all use the same `io_service`]
-
 [note Inheriting [globalref boost::process::extend::require_io_service require_io_service] is necessary, so [funcref boost::process::system system] provides one.]
 
 Additionally the handler can provide a function that is invoked when the child process exits. This is done through __async_handler__.
@@ -134,6 +132,8 @@ struct async_bar : __handler, __async_handler__
 
 
 [caution `on_exit_handler` does not default and is always required when [classref boost::process::extend::async_handler async_handler] is inherited. ]
+
+[caution `on_exit_handler` uses `boost::asio::signal_set` to listen for SIGCHLD on posix. The application must not also register a signal handler for SIGCHLD using functions such as `signal()` or `sigaction()` (but using `boost::asio::signal_set` is fine). ]
 
 [endsect]
 

--- a/include/boost/process/async.hpp
+++ b/include/boost/process/async.hpp
@@ -118,7 +118,9 @@ chlid c2("ls", on_exit=exit_code);
 
 \note The handler is not invoked when the launch fails.
 \warning When used \ref ignore_error it might get invoked on error.
-\warning All `on_exit` use one signal(SIGCHLD) on posix, which is only guaranteed to work when all use the same `io_context`.
+\warning `on_exit` uses `boost::asio::signal_set` to listen for `SIGCHLD` on posix, and so has the
+same restrictions as that class (do not register a handler for `SIGCHLD` except by using
+`boost::asio::signal_set`).
  */
 constexpr static ::boost::process::detail::on_exit_ on_exit{};
 #endif


### PR DESCRIPTION
There may be other io_context instances with child instances, and child
instances with no associated io_context. If we pass 0 to ::waitpid(), we
will reap their processes as well, without updating the state of the
corresponding child instance.

Instead, we call `::waitpid` once for each child we are watching for.
This has some amount of overhead (multiple system calls), but ensures
correct behaviour (providing nothing other than an asio::signal_set is
watching for SIGCHLD).

Fixes #143.