### PR TITLE
Add unit tests for async exit watching with multiple io_contexts

### DIFF
--- a/test/Jamfile.jam
+++ b/test/Jamfile.jam
@@ -21,6 +21,7 @@ if [ os.name ] = NT
 project : requirements
   <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
   <toolset>msvc:<define>_CRT_SECURE_NO_DEPRECATE
+  <toolset>msvc:<cxxflags>/bigobj
   <target-os>windows:<define>WIN32_LEAN_AND_MEAN
   <target-os>linux:<linkflags>-lpthread
   <os>NT,<toolset>cw:<library>ws2_32

--- a/test/async.cpp
+++ b/test/async.cpp
@@ -35,12 +35,71 @@ BOOST_AUTO_TEST_CASE(async_wait, *boost::unit_test::timeout(2))
 
     boost::asio::io_context io_context;
 
+    std::error_code ec;
+
+    bool exit_called_for_c1 = false;
+    int exit_code_c1 = 0;
+    bp::child c1(
+        master_test_suite().argv[1],
+        "test", "--exit-code", "123",
+        ec,
+        io_context,
+        bp::on_exit([&](int exit, const std::error_code& ec_in)
+                {
+                    BOOST_CHECK(!exit_called_for_c1);
+                    exit_code_c1 = exit; exit_called_for_c1=true;
+                    BOOST_CHECK(!ec_in);
+                })
+    );
+    BOOST_REQUIRE(!ec);
+
+    bool exit_called_for_c2 = false;
+    int exit_code_c2 = 0;
+    bp::child c2(
+        master_test_suite().argv[1],
+        "test", "--exit-code", "21",
+        ec,
+        io_context,
+        bp::on_exit([&](int exit, const std::error_code& ec_in)
+                {
+                    BOOST_CHECK(!exit_called_for_c2);
+                    exit_code_c2 = exit; exit_called_for_c2=true;
+                    BOOST_CHECK(!ec_in);
+                })
+    );
+    BOOST_REQUIRE(!ec);
+
+    io_context.run();
+
+    BOOST_CHECK(exit_called_for_c1);
+    BOOST_CHECK_EQUAL(exit_code_c1, 123);
+    BOOST_CHECK_EQUAL(c1.exit_code(), 123);
+
+    BOOST_CHECK(exit_called_for_c2);
+    BOOST_CHECK_EQUAL(exit_code_c2, 21);
+    BOOST_CHECK_EQUAL(c2.exit_code(), 21);
+}
+
+BOOST_AUTO_TEST_CASE(async_wait_sync_wait, *boost::unit_test::timeout(3))
+{
+    using boost::unit_test::framework::master_test_suite;
+    using namespace boost::asio;
+
+    boost::asio::io_context io_context;
+
     bool exit_called = false;
     int exit_code = 0;
     std::error_code ec;
-    bp::child c(
+    bp::child c1(
         master_test_suite().argv[1],
-        "test", "--exit-code", "123",
+        "test", "--exit-code", "1",
+        ec
+    );
+    BOOST_REQUIRE(!ec);
+
+    bp::child c2(
+        master_test_suite().argv[1],
+        "test", "--exit-code", "2", "--wait", "1",
         ec,
         io_context,
         bp::on_exit([&](int exit, const std::error_code& ec_in)
@@ -49,12 +108,73 @@ BOOST_AUTO_TEST_CASE(async_wait, *boost::unit_test::timeout(2))
                     BOOST_CHECK(!ec_in);
                 })
     );
-
     BOOST_REQUIRE(!ec);
+
     io_context.run();
+    // Regression test for #143: make sure the async SIGCHLD handler on POSIX does not reap the
+    // child c1 is watching (this will error if so)
+    c1.wait(ec);
+    BOOST_REQUIRE(!ec);
+
     BOOST_CHECK(exit_called);
-    BOOST_CHECK_EQUAL(exit_code, 123);
-    BOOST_CHECK_EQUAL(c.exit_code(), 123);
+    BOOST_CHECK_EQUAL(exit_code, 2);
+    BOOST_CHECK_EQUAL(c2.exit_code(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(async_wait_different_contexts, *boost::unit_test::timeout(3))
+{
+    using boost::unit_test::framework::master_test_suite;
+    using namespace boost::asio;
+
+    boost::asio::io_context io_context1;
+    boost::asio::io_context io_context2;
+
+    std::error_code ec;
+
+    bool exit_called_for_c1 = false;
+    int exit_code_c1 = 0;
+    bp::child c1(
+        master_test_suite().argv[1],
+        "test", "--exit-code", "1",
+        ec,
+        io_context1,
+        bp::on_exit([&](int exit, const std::error_code& ec_in)
+                {
+                    BOOST_CHECK(!exit_called_for_c1);
+                    exit_code_c1 = exit; exit_called_for_c1=true;
+                    BOOST_CHECK(!ec_in);
+                })
+    );
+    BOOST_REQUIRE(!ec);
+
+    bool exit_called_for_c2 = false;
+    int exit_code_c2 = 0;
+    bp::child c2(
+        master_test_suite().argv[1],
+        "test", "--exit-code", "2", "--wait", "1",
+        ec,
+        io_context2,
+        bp::on_exit([&](int exit, const std::error_code& ec_in)
+                {
+                    BOOST_CHECK(!exit_called_for_c2);
+                    exit_code_c2 = exit; exit_called_for_c2=true;
+                    BOOST_CHECK(!ec_in);
+                })
+    );
+    BOOST_REQUIRE(!ec);
+
+    // Regression test for #143: make sure each io_context handles its own children
+    io_context2.run();
+    io_context1.run();
+    c1.wait(ec);
+    BOOST_REQUIRE(!ec);
+
+    BOOST_CHECK(exit_called_for_c1);
+    BOOST_CHECK_EQUAL(exit_code_c1, 1);
+    BOOST_CHECK_EQUAL(c1.exit_code(), 1);
+    BOOST_CHECK(exit_called_for_c2);
+    BOOST_CHECK_EQUAL(exit_code_c2, 2);
+    BOOST_CHECK_EQUAL(c2.exit_code(), 2);
 }
 
 


### PR DESCRIPTION
These tests fail without the commit "Only reap children we are watching
for when handling SIGCHLD" (#145) applied, and succeed with it applied.