### PR TITLE
Always set arguments on POSIX

### DIFF
--- a/include/boost/process/detail/posix/basic_cmd.hpp
+++ b/include/boost/process/detail/posix/basic_cmd.hpp
@@ -118,12 +118,8 @@ struct exe_cmd_init<char> : boost::process::detail::api::handler_base_ext
         else
             exec.exe = &exe.front();
 
-
-        if (!args.empty())
-        {
-            cmd_impl = make_cmd();
-            exec.cmd_line = cmd_impl.data();
-        }
+        cmd_impl = make_cmd();
+        exec.cmd_line = cmd_impl.data();
     }
     static exe_cmd_init exe_args(std::string && exe, std::vector<std::string> && args) {return exe_cmd_init(std::move(exe), std::move(args));}
     static exe_cmd_init cmd     (std::string && cmd)
@@ -163,8 +159,10 @@ std::vector<char*> exe_cmd_init<char>::make_cmd()
     if (!exe.empty())
         vec.push_back(&exe.front());
 
-    for (auto & v : args)
-        vec.push_back(&v.front());
+    if (!args.empty()) {
+        for (auto & v : args)
+            vec.push_back(&v.front());
+    }
 
     vec.push_back(nullptr);
 

--- a/test/Jamfile.jam
+++ b/test/Jamfile.jam
@@ -45,6 +45,10 @@ exe sparring_partner : sparring_partner.cpp program_options system filesystem io
     <warnings>off <target-os>windows:<source>shell32
     ;
 
+exe exit_argc : exit_argc.cpp :
+    <warnings>off <target-os>windows:<source>shell32
+    ;
+
 exe sub_launch : sub_launcher.cpp program_options iostreams system filesystem : <warnings>off <target-os>windows:<source>shell32 ;
 
 test-suite bare :
@@ -59,6 +63,7 @@ test-suite bare :
 test-suite with-valgrind :
     [ run async.cpp       system thread filesystem            : : sparring_partner ]
     [ run async_fut.cpp   system thread filesystem            : : sparring_partner ]
+    [ run args_handling.cpp  system thread filesystem         : : exit_argc        ]
     [ run args_cmd.cpp    system filesystem                   : : sparring_partner ]
     [ run wargs_cmd.cpp    system filesystem                  : : sparring_partner ]
     [ run bind_stderr.cpp     filesystem                      : : sparring_partner ]

--- a/test/args_handling.cpp
+++ b/test/args_handling.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2006, 2007 Julio M. Merino Vidal
+// Copyright (c) 2008 Ilya Sokolov, Boris Schaeling
+// Copyright (c) 2009 Boris Schaeling
+// Copyright (c) 2010 Felipe Tanus, Boris Schaeling
+// Copyright (c) 2011, 2012 Jeff Flinn, Boris Schaeling
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_IGNORE_SIGCHLD
+#include <boost/test/included/unit_test.hpp>
+
+#include <system_error>
+#include <boost/filesystem.hpp>
+
+#include <boost/process/cmd.hpp>
+#include <boost/process/error.hpp>
+#include <boost/process/child.hpp>
+
+namespace bp = boost::process;
+
+
+BOOST_AUTO_TEST_CASE(implicit_args_fs_path)
+{
+    using boost::unit_test::framework::master_test_suite;
+
+    boost::filesystem::path exe = master_test_suite().argv[1];
+
+    std::error_code ec;
+    bp::child c(
+        exe,
+        ec
+    );
+    BOOST_REQUIRE(!ec);
+
+    c.wait(ec);
+    BOOST_REQUIRE(!ec);
+
+    BOOST_CHECK(c.exit_code() == 1); // should pass at least exe!
+}
+
+BOOST_AUTO_TEST_CASE(implicit_args_cmd)
+{
+    using boost::unit_test::framework::master_test_suite;
+
+    std::error_code ec;
+    bp::child c(
+        master_test_suite().argv[1],
+        ec
+    );
+    BOOST_REQUIRE(!ec);
+
+    c.wait(ec);
+    BOOST_REQUIRE(!ec);
+
+    BOOST_CHECK(c.exit_code() == 1); // should pass at least exe!
+}
+
+BOOST_AUTO_TEST_CASE(explicit_args_fs_path)
+{
+    using boost::unit_test::framework::master_test_suite;
+
+    boost::filesystem::path exe = master_test_suite().argv[1];
+
+    std::error_code ec;
+    bp::child c(
+        exe,
+        "hello",
+        ec
+    );
+    BOOST_REQUIRE(!ec);
+
+    c.wait(ec);
+    BOOST_REQUIRE(!ec);
+
+    BOOST_CHECK(c.exit_code() == 2); // exe + "hello"
+}

--- a/test/args_handling.cpp
+++ b/test/args_handling.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2009 Boris Schaeling
 // Copyright (c) 2010 Felipe Tanus, Boris Schaeling
 // Copyright (c) 2011, 2012 Jeff Flinn, Boris Schaeling
+// Copyright (c) 2018 Oxford Nanopore Technologies
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/test/exit_argc.cpp
+++ b/test/exit_argc.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Alex Merry
+// Copyright (c) 2018 Oxford Nanopore Technologies
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/test/exit_argc.cpp
+++ b/test/exit_argc.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2018 Alex Merry
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iostream>
+
+int main(int argc, char *argv[])
+{
+    for (int i = 0; i < argc; ++i) {
+        std::cout << argv[i] << '\n';
+    }
+    return argc;
+}


### PR DESCRIPTION
Explicitly specifying an executable (either with boost::filesystem::path
or boost::process::exe) and no arguments causes NULL to be passed as the
argument list.

Not only is this unexpected behaviour for the child process (which
doesn't even have argv[0]), it is not portable across UNIX systems. From
the execve(2) man page on Linux:

"On Linux, either argv or envp can be specified as NULL, which has the
same effect as specifying these arguments as a pointer to a list
containing a single NULL pointer.  Do not take advantage of this
misfeature!  It is nonstandard and nonportable:  on  most other UNIX
systems doing this will result in an error (EFAULT)."