### PR TITLE
Return the same exit status in the async handler as the sync method

### DIFF
--- a/include/boost/process/detail/posix/io_context_ref.hpp
+++ b/include/boost/process/detail/posix/io_context_ref.hpp
@@ -18,6 +18,7 @@
 
 
 #include <boost/process/detail/posix/sigchld_service.hpp>
+#include <boost/process/detail/posix/is_running.hpp>
 
 #include <functional>
 #include <type_traits>
@@ -95,11 +96,11 @@ struct io_context_ref : handler_base_ext
         auto & es = exec.exit_status;
 
         auto wh = [funcs, es](int val, const std::error_code & ec)
-				{
-        			es->store(val);
+                {
+                    es->store(val);
                     for (auto & func : funcs)
-                        func(WEXITSTATUS(val), ec);
-				};
+                        func(::boost::process::detail::posix::eval_exit_status(val), ec);
+                };
 
         sigchld_service.async_wait(exec.pid, std::move(wh));
     }

--- a/test/exit_code.cpp
+++ b/test/exit_code.cpp
@@ -48,6 +48,26 @@ BOOST_AUTO_TEST_CASE(sync_wait)
     c.wait();
 }
 
+BOOST_AUTO_TEST_CASE(sync_wait_terminated)
+{
+    using boost::unit_test::framework::master_test_suite;
+
+    std::error_code ec;
+    bp::child c(
+        master_test_suite().argv[1],
+        "test", "--abort",
+        ec
+    );
+    BOOST_REQUIRE(!ec);
+    c.wait();
+    int exit_code = c.exit_code();
+
+
+    BOOST_CHECK(exit_code != 0);
+
+    c.wait();
+}
+
 #if defined(BOOST_WINDOWS_API)
 struct wait_handler
 {

--- a/test/sparring_partner.cpp
+++ b/test/sparring_partner.cpp
@@ -51,6 +51,7 @@ int main(int argc, char *argv[])
         ("is-nul-stdout", bool_switch())
         ("is-nul-stderr", bool_switch())
         ("loop", bool_switch())
+        ("abort", bool_switch())
         ("prefix", value<std::string>())
         ("prefix-once", value<std::string>())
         ("pwd", bool_switch())
@@ -146,6 +147,10 @@ int main(int argc, char *argv[])
     else if (vm["loop"].as<bool>())
     {
         while (true);
+    }
+    else if (vm["abort"].as<bool>())
+    {
+        std::abort();
     }
     else if (vm.count("prefix"))
     {


### PR DESCRIPTION
Previously, if the process terminated via a signal on posix, the async
handler would provide an exit status of 0.