### PR TITLE
is_running fixes

### DIFF
--- a/include/boost/process/detail/posix/is_running.hpp
+++ b/include/boost/process/detail/posix/is_running.hpp
@@ -13,9 +13,11 @@
 
 namespace boost { namespace process { namespace detail { namespace posix {
 
-
+// Use the "stopped" state (WIFSTOPPED) to indicate "not terminated".
+// This bit arrangement of status codes is not guaranteed by POSIX, but (according to comments in
+// the glibc <bits/waitstatus.h> header) is the same across systems in practice.
 constexpr int still_active = 0x7F;
-static_assert(!WIFEXITED(still_active), "Internal Error");
+static_assert(!WIFEXITED(still_active) && !WIFSIGNALED(still_active), "Internal Error");
 
 inline bool is_running(int code)
 {

--- a/include/boost/process/detail/posix/is_running.hpp
+++ b/include/boost/process/detail/posix/is_running.hpp
@@ -25,7 +25,7 @@ inline bool is_running(int code)
 inline bool is_running(const child_handle &p, int & exit_code, std::error_code &ec) noexcept
 {
     int status;
-    auto ret = ::waitpid(p.pid, &status, WNOHANG|WUNTRACED); 
+    auto ret = ::waitpid(p.pid, &status, WNOHANG);
 
     if (ret == -1)
     {
@@ -63,10 +63,6 @@ inline int eval_exit_status(int code)
     else if (WIFSIGNALED(code))
     {
         return WTERMSIG(code);
-    }
-    else if (WIFSTOPPED(code))
-    {
-        return WSTOPSIG(code);
     }
     else
     {

--- a/test/async.cpp
+++ b/test/async.cpp
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(async_wait_different_contexts, *boost::unit_test::timeout(3
     BOOST_CHECK_EQUAL(c2.exit_code(), 2);
 }
 
-BOOST_AUTO_TEST_CASE(async_wait_terminated, *boost::unit_test::timeout(2))
+BOOST_AUTO_TEST_CASE(async_wait_abort, *boost::unit_test::timeout(2))
 {
     using boost::unit_test::framework::master_test_suite;
     using namespace boost::asio;

--- a/test/exit_code.cpp
+++ b/test/exit_code.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(sync_wait)
     c.wait();
 }
 
-BOOST_AUTO_TEST_CASE(sync_wait_terminated)
+BOOST_AUTO_TEST_CASE(sync_wait_abort)
 {
     using boost::unit_test::framework::master_test_suite;
 


### PR DESCRIPTION
Remove code in is_running that deals with processes in a stopped state (which is not important to termination), and some other minor fixes.