### PR TITLE
Make exit status POSIX-compliant when process received signal

### DIFF
--- a/include/boost/process/detail/posix/is_running.hpp
+++ b/include/boost/process/detail/posix/is_running.hpp
@@ -64,7 +64,7 @@ inline int eval_exit_status(int code)
     }
     else if (WIFSIGNALED(code))
     {
-        return WTERMSIG(code);
+        return WTERMSIG(code) + 128;
     }
     else
     {


### PR DESCRIPTION
With this change, we can distinguish whether a process terminated normally (either with success or with failure) or abnormally (by receiving a signal) based on the exit status.

POSIX specifies that the exit status of abnormally terminated processes should be greater than 128; for example: [https://www.unix.com/man-page/posix/1P/wait/](https://www.unix.com/man-page/posix/1P/wait/)

> If the process terminated abnormally due to the receipt  of  a  signal, the  exit status shall be greater than 128 and shall be distinct from the exit status generated by other signals, but the exact value is unspecified.

Although the exit status is unspecified, the increase of +128 is in line with lots of shells, e.g. bash, dash, zsh, mksh, tcsh.