### PR TITLE
fix exit code when running under asio

### DIFF
--- a/include/boost/process/detail/posix/io_context_ref.hpp
+++ b/include/boost/process/detail/posix/io_context_ref.hpp
@@ -85,10 +85,6 @@ struct io_context_ref : handler_base_ext
                         typename std::remove_reference< boost::mpl::_ > ::type
                         >>(exec.seq);
 
-        //ok, check if there are actually any.
-        if (boost::fusion::empty(asyncs))
-            return;
-
         std::vector<std::function<void(int, const std::error_code & ec)>> funcs;
         funcs.reserve(boost::fusion::size(asyncs));
         boost::fusion::for_each(asyncs, async_handler_collector<Executor>(exec, funcs));

--- a/include/boost/process/detail/windows/io_context_ref.hpp
+++ b/include/boost/process/detail/windows/io_context_ref.hpp
@@ -87,12 +87,6 @@ struct io_context_ref : boost::process::detail::handler_base
                       typename std::remove_reference< boost::mpl::_ > ::type
                       >>(exec.seq);
 
-        //ok, check if there are actually any.
-        if (boost::fusion::empty(asyncs))
-        {
-            return;
-        }
-
         ::boost::winapi::PROCESS_INFORMATION_ & proc = exec.proc_info;
         auto this_proc = ::boost::winapi::GetCurrentProcess();
 

--- a/test/exit_code.cpp
+++ b/test/exit_code.cpp
@@ -125,3 +125,26 @@ BOOST_AUTO_TEST_CASE(async_wait)
     io_context.run();
     std::cout << "async_wait 2" << std::endl;
 }
+
+BOOST_AUTO_TEST_CASE(async_nowait)
+{
+    // No need to call wait when passing an io_context
+    using boost::unit_test::framework::master_test_suite;
+    using namespace boost::asio;
+
+    std::error_code ec;
+    boost::asio::io_context io_context;
+    bp::child c(
+        master_test_suite().argv[1],
+        "test", "--exit-code", "123",
+        ec,
+        io_context
+    );
+    BOOST_REQUIRE(!ec);
+
+    std::cout << "async_nowait 1" << std::endl;
+    io_context.run();
+    std::cout << "async_nowait 2" << std::endl;
+
+    BOOST_CHECK_EQUAL(123, c.exit_code());
+}


### PR DESCRIPTION
When using a boost::asio::io_context, `io_context_ref` is expected to
handle SIGCHLD, call waitpid and store the exit code of the process. In
addition to storing the exit code, it also handles calling
`on_exit_handler` on any `async_handler` instances (e.g. when using
`on_exit`).

However, there was a check that only set up the SIGCHLD handling when
there were any `async_handler` instances present. So when there are none
(which is usually the case), the exit code is also not set, resulting in
an invalid result when calling `exit_code()`. To fix this, the check is
simply removed, so now a SIGCHLD handler is always set up when an
`io_context` is passed.

This check was introduced in commit 7017150 (added specialization for
posix && added conditional for io_service_ref).

This PR was tested on Linux only, but I added a testcase that should help verifying it on Windows.