### PR TITLE
Add WINAPI calling convention to Windows Job API

### DIFF
--- a/include/boost/process/detail/windows/job_workaround.hpp
+++ b/include/boost/process/detail/windows/job_workaround.hpp
@@ -82,7 +82,7 @@ typedef struct _JOBOBJECT_EXTENDED_LIMIT_INFORMATION_ {
   _Out_opt_ LPDWORD            lpReturnLength
 );
  */
-typedef ::boost::winapi::BOOL_  (*query_information_job_object_p)(
+typedef ::boost::winapi::BOOL_  (WINAPI *query_information_job_object_p)(
         ::boost::winapi::HANDLE_,
         JOBOBJECTINFOCLASS_,
         void *,
@@ -110,7 +110,7 @@ inline ::boost::winapi::BOOL_ query_information_job_object(
   _In_ DWORD              cbJobObjectInfoLength
 );*/
 
-typedef ::boost::winapi::BOOL_  (*set_information_job_object_p)(
+typedef ::boost::winapi::BOOL_  (WINAPI *set_information_job_object_p)(
         ::boost::winapi::HANDLE_,
         JOBOBJECTINFOCLASS_,
         void *,


### PR DESCRIPTION
Unspecified calling convention for query_information_job_object_p and set_information_job_object_p leads to stack corruption when project uses __cdecl(which is default in my VS2017) instead of __stdcall.