### PR TITLE
Implement move operations for streams

### DIFF
--- a/include/boost/process/pipe.hpp
+++ b/include/boost/process/pipe.hpp
@@ -265,31 +265,40 @@ public:
     basic_pipebuf<CharT, Traits>* rdbuf() {return &_buf;};
 
     ///Default constructor.
-    basic_ipstream() : std::basic_istream<CharT, Traits>(nullptr)
+    basic_ipstream() : std::basic_istream<CharT, Traits>(&_buf)
     {
-        std::basic_istream<CharT, Traits>::rdbuf(&_buf);
-    };
+    }
     ///Copy constructor.
     basic_ipstream(const basic_ipstream & ) = delete;
     ///Move constructor.
-    basic_ipstream(basic_ipstream && ) = default;
+	basic_ipstream(basic_ipstream && rhs) : basic_ipstream()
+	{
+		std::basic_istream<CharT, Traits>::swap(rhs);
+		_buf = std::move(rhs._buf);
+	}
 
     ///Move construct from a pipe.
-    basic_ipstream(pipe_type && p)      : std::basic_istream<CharT, Traits>(nullptr), _buf(std::move(p))
+    basic_ipstream(pipe_type && p)      : basic_ipstream(), _buf(std::move(p))
     {
-        std::basic_istream<CharT, Traits>::rdbuf(&_buf);
     }
 
     ///Copy construct from a pipe.
-    basic_ipstream(const pipe_type & p) : std::basic_istream<CharT, Traits>(nullptr), _buf(p)
+    basic_ipstream(const pipe_type & p) : basic_ipstream(), _buf(p)
     {
-        std::basic_istream<CharT, Traits>::rdbuf(&_buf);
     }
 
     ///Copy assignment.
     basic_ipstream& operator=(const basic_ipstream & ) = delete;
     ///Move assignment
-    basic_ipstream& operator=(basic_ipstream && ) = default;
+	basic_ipstream& operator=(basic_ipstream && rhs)
+	{
+		if (this != std::addressof(rhs))
+		{
+			std::basic_istream<CharT, Traits>::swap(rhs);
+			_buf = std::move(rhs._buf);
+		}
+		return *this;
+	}
     ///Move assignment of a pipe.
     basic_ipstream& operator=(pipe_type && p)
     {
@@ -341,29 +350,38 @@ public:
     basic_pipebuf<CharT, Traits>* rdbuf() const {return _buf;};
 
     ///Default constructor.
-    basic_opstream() : std::basic_ostream<CharT, Traits>(nullptr)
+    basic_opstream() : std::basic_ostream<CharT, Traits>(&_buf)
     {
-        std::basic_ostream<CharT, Traits>::rdbuf(&_buf);
-    };
+    }
     ///Copy constructor.
     basic_opstream(const basic_opstream & ) = delete;
     ///Move constructor.
-    basic_opstream(basic_opstream && ) = default;
+	basic_opstream(basic_opstream && rhs) : basic_opstream()
+	{
+		std::basic_ostream<CharT, Traits>::swap(rhs);
+		_buf = std::move(rhs._buf);
+	}
 
     ///Move construct from a pipe.
-    basic_opstream(pipe_type && p)      : std::basic_ostream<CharT, Traits>(nullptr), _buf(std::move(p))
+    basic_opstream(pipe_type && p)      : basic_ipstream(), _buf(std::move(p))
     {
-        std::basic_ostream<CharT, Traits>::rdbuf(&_buf);
-    };
+    }
     ///Copy construct from a pipe.
-    basic_opstream(const pipe_type & p) : std::basic_ostream<CharT, Traits>(nullptr), _buf(p)
+    basic_opstream(const pipe_type & p) : basic_ipstream(), _buf(p)
     {
-        std::basic_ostream<CharT, Traits>::rdbuf(&_buf);
-    };
+    }
     ///Copy assignment.
     basic_opstream& operator=(const basic_opstream & ) = delete;
     ///Move assignment
-    basic_opstream& operator=(basic_opstream && ) = default;
+	basic_opstream& operator=(basic_opstream && rhs)
+	{
+		if (this != std::addressof(rhs))
+		{
+			std::basic_ostream<CharT, Traits>::swap(rhs);
+			_buf = std::move(rhs._buf);
+		}
+		return *this;
+	}
     ///Move assignment of a pipe.
     basic_opstream& operator=(pipe_type && p)
     {

--- a/include/boost/process/pipe.hpp
+++ b/include/boost/process/pipe.hpp
@@ -265,8 +265,9 @@ public:
     basic_pipebuf<CharT, Traits>* rdbuf() {return &_buf;};
 
     ///Default constructor.
-    basic_ipstream() : std::basic_istream<CharT, Traits>(&_buf)
+    basic_ipstream() : std::basic_istream<CharT, Traits>(nullptr)
     {
+		std::basic_istream<CharT, Traits>::rdbuf(&_buf);
     }
     ///Copy constructor.
     basic_ipstream(const basic_ipstream & ) = delete;
@@ -350,8 +351,9 @@ public:
     basic_pipebuf<CharT, Traits>* rdbuf() const {return _buf;};
 
     ///Default constructor.
-    basic_opstream() : std::basic_ostream<CharT, Traits>(&_buf)
+    basic_opstream() : std::basic_ostream<CharT, Traits>(nullptr)
     {
+		std::basic_ostream<CharT, Traits>::rdbuf(&_buf);
     }
     ///Copy constructor.
     basic_opstream(const basic_opstream & ) = delete;
@@ -441,22 +443,32 @@ public:
     ///Copy constructor.
     basic_pstream(const basic_pstream & ) = delete;
     ///Move constructor.
-    basic_pstream(basic_pstream && ) = default;
+	basic_pstream(basic_pstream && rhs) : basic_pstream()
+	{
+		std::basic_iostream<CharT, Traits>::swap(rhs);
+		_buf = std::move(rhs._buf);
+	}
 
     ///Move construct from a pipe.
-    basic_pstream(pipe_type && p)      : std::basic_iostream<CharT, Traits>(nullptr), _buf(std::move(p))
+    basic_pstream(pipe_type && p)      : basic_pstream(), _buf(std::move(p))
     {
-        std::basic_iostream<CharT, Traits>::rdbuf(&_buf);
-    };
+    }
     ///Copy construct from a pipe.
-    basic_pstream(const pipe_type & p) : std::basic_iostream<CharT, Traits>(nullptr), _buf(p)
+    basic_pstream(const pipe_type & p) : basic_pstream, _buf(p)
     {
-        std::basic_iostream<CharT, Traits>::rdbuf(&_buf);
-    };
+    }
     ///Copy assignment.
     basic_pstream& operator=(const basic_pstream & ) = delete;
     ///Move assignment
-    basic_pstream& operator=(basic_pstream && ) = default;
+	basic_pstream& operator=(basic_pstream && rhs)
+	{
+		if (this != std::addressof(rhs))
+		{
+			std::basic_iostream<CharT, Traits>::swap(rhs);
+			_buf = std::move(rhs._buf);
+		}
+		return *this;
+	}
     ///Move assignment of a pipe.
     basic_pstream& operator=(pipe_type && p)
     {


### PR DESCRIPTION
Default move opertaions for basic_ipstream, basic_opstream, basic_pstream are actually "defaulted deleted". You can see details [here](http://talesofcpp.fusionfenix.com/post-24/episode-eleven-to-kill-a-move-constructor).
Example:
```c++
boost::process::ipstream a;
boost::process::ipstream b(std::move(a));   // error!
boost::process::ipstream c = std::move(b); // error!
```
Because of virtual inheritance in std::basic_istream : virtual public basic_ios, defaulted move operations becomes deleted, and compiler tries to use copy operations that are explicitly deleted.

I also create a simple demonstration of it:
```c++
//like std::basic_ios
class non_movable
{
public:
	non_movable() = default;
	non_movable(const non_movable&) = delete;
	non_movable& operator=(const non_movable&) = delete;
};

//like std::basic_istream
class user_defined_movable : virtual public non_movable
{
public:
	user_defined_movable() = default;
	user_defined_movable(const user_defined_movable&) = delete;
	user_defined_movable& operator=(const user_defined_movable&) = delete;
	user_defined_movable(user_defined_movable&&) {};
	user_defined_movable& operator=(user_defined_movable&&) {};
};

//like boost::process::basic_ipstream
class defaulted_movable : public user_defined_movable
{
public:
	defaulted_movable() = default;
	defaulted_movable(const defaulted_movable&) = delete;
	defaulted_movable& operator=(const defaulted_movable&) = delete;
	defaulted_movable(defaulted_movable&&) = default;
	defaulted_movable& operator=(defaulted_movable&&) = default;
};
defaulted_movable a;
defaulted_movable b(std::move(a));	// error!
defaulted_movable c = std::move(b);	// error!
```

So we need to implement them ourselves.
