### PR TITLE
Make set_startup_info_ex OR creation_flags instead of setting them

### DIFF
--- a/include/boost/process/detail/windows/executor.hpp
+++ b/include/boost/process/detail/windows/executor.hpp
@@ -83,8 +83,8 @@ struct startup_info_impl
 
     void set_startup_info_ex()
     {
-       startup_info.cb = sizeof(startup_info_ex_t);
-       creation_flags  = ::boost::winapi::EXTENDED_STARTUPINFO_PRESENT_;
+       startup_info.cb  = sizeof(startup_info_ex_t);
+       creation_flags  |= ::boost::winapi::EXTENDED_STARTUPINFO_PRESENT_;
     }
 };
 


### PR DESCRIPTION
This ensures that if anything else has set any creation_flags (eg: by
setting a unicode environment), those flags will be preserved.