### PR TITLE
Fix warnings: decl. of 'x' hides class member

### DIFF
--- a/doc/extend.qbk
+++ b/doc/extend.qbk
@@ -120,8 +120,8 @@ struct async_bar : __handler, __async_handler__
     template<typename Executor>
     std::function<void(int, const std::error_code&)> on_exit_handler(Executor & exec)
     {
-        auto handler = this->handler;
-        return [handler](int exit_code, const std::error_code & ec)
+        auto handler_ = this->handler;
+        return [handler_](int exit_code, const std::error_code & ec)
                {
                    std::cout << "hello world, I exited with " << exit_code << std::endl; 
                };

--- a/include/boost/process/detail/posix/async_in.hpp
+++ b/include/boost/process/detail/posix/async_in.hpp
@@ -41,28 +41,28 @@ struct async_in_buffer : ::boost::process::detail::posix::handler_base_ext,
     template <typename Executor>
     inline void on_success(Executor)
     {
-        auto  pipe              = this->pipe;
+        auto  pipe_              = this->pipe;
         if (this->promise)
         {
-            auto promise = this->promise;
+            auto promise_ = this->promise;
 
-            boost::asio::async_write(*pipe, buf,
-                [pipe, promise](const boost::system::error_code & ec, std::size_t)
+            boost::asio::async_write(*pipe_, buf,
+                [pipe_, promise_](const boost::system::error_code & ec, std::size_t)
                 {
                     if (ec && (ec.value() != EBADF) && (ec.value() != EPERM) && (ec.value() != ENOENT))
                     {
                         std::error_code e(ec.value(), std::system_category());
-                        promise->set_exception(std::make_exception_ptr(process_error(e)));
+                        promise_->set_exception(std::make_exception_ptr(process_error(e)));
                     }
                     else
-                        promise->set_value();
+                        promise_->set_value();
                 });
         }
         else
-            boost::asio::async_write(*pipe, buf,
-                [pipe](const boost::system::error_code&, std::size_t){});
+            boost::asio::async_write(*pipe_, buf,
+                [pipe_](const boost::system::error_code&, std::size_t){});
 
-        std::move(*pipe).source().close();
+        std::move(*pipe_).source().close();
 
         this->pipe = nullptr;
     }

--- a/include/boost/process/detail/posix/async_out.hpp
+++ b/include/boost/process/detail/posix/async_out.hpp
@@ -114,30 +114,30 @@ struct async_out_future : ::boost::process::detail::posix::handler_base_ext,
     template <typename Executor>
     inline void on_success(Executor &)
     {
-        auto pipe = this->pipe;
+        auto pipe_ = this->pipe;
 
-        auto buffer  = this->buffer;
-        auto promise = this->promise;
+        auto buffer_  = this->buffer;
+        auto promise_ = this->promise;
 
-        boost::asio::async_read(*pipe, *buffer,
-                [pipe, buffer, promise](const boost::system::error_code& ec, std::size_t)
+        boost::asio::async_read(*pipe_, *buffer_,
+                [pipe_, buffer_, promise_](const boost::system::error_code& ec, std::size_t)
                 {
                     if (ec && (ec.value() != ENOENT))
                     {
                         std::error_code e(ec.value(), std::system_category());
-                        promise->set_exception(std::make_exception_ptr(process_error(e)));
+                        promise_->set_exception(std::make_exception_ptr(process_error(e)));
                     }
                     else
                     {
-                        std::istream is (buffer.get());
+                        std::istream is (buffer_.get());
                         Type arg;
-                        arg.resize(buffer->size());
-                        is.read(&*arg.begin(), buffer->size());
-                        promise->set_value(std::move(arg));
+                        arg.resize(buffer_->size());
+                        is.read(&*arg.begin(), buffer_->size());
+                        promise_->set_value(std::move(arg));
                     }
                 });
 
-        std::move(*pipe).sink().close();
+        std::move(*pipe_).sink().close();
         this->pipe = nullptr;
     }
 

--- a/include/boost/process/detail/windows/async_in.hpp
+++ b/include/boost/process/detail/windows/async_in.hpp
@@ -48,28 +48,28 @@ struct async_in_buffer : ::boost::process::detail::windows::handler_base_ext,
     template <typename Executor>
     inline void on_success(Executor&)
     {
-        auto pipe = this->pipe;
+        auto pipe_ = this->pipe;
 
         if (this->promise)
         {
-            auto promise = this->promise;
+            auto promise_ = this->promise;
 
-            boost::asio::async_write(*pipe, buf,
-                [promise](const boost::system::error_code & ec, std::size_t)
+            boost::asio::async_write(*pipe_, buf,
+                [promise_](const boost::system::error_code & ec, std::size_t)
                 {
                     if (ec && (ec.value() != ::boost::winapi::ERROR_BROKEN_PIPE_))
                     {
                         std::error_code e(ec.value(), std::system_category());
-                        promise->set_exception(std::make_exception_ptr(process_error(e)));
+                        promise_->set_exception(std::make_exception_ptr(process_error(e)));
                     }
-                    promise->set_value();
+                    promise_->set_value();
                 });
         }
         else
-            boost::asio::async_write(*pipe, buf,
-                [pipe](const boost::system::error_code&, std::size_t){});
+            boost::asio::async_write(*pipe_, buf,
+                [pipe_](const boost::system::error_code&, std::size_t){});
 
-        std::move(*pipe).source().close();
+        std::move(*pipe_).source().close();
 
 
         this->pipe = nullptr;

--- a/include/boost/process/detail/windows/async_out.hpp
+++ b/include/boost/process/detail/windows/async_out.hpp
@@ -80,10 +80,10 @@ struct async_out_buffer : ::boost::process::detail::windows::handler_base_ext,
     template <typename Executor>
     inline void on_success(Executor&)
     {
-        auto pipe = this->pipe;
-        boost::asio::async_read(*pipe, buf,
-                [pipe](const boost::system::error_code&, std::size_t){});
-        std::move(*pipe).sink().close();
+        auto pipe_ = this->pipe;
+        boost::asio::async_read(*pipe_, buf,
+                [pipe_](const boost::system::error_code&, std::size_t){});
+        std::move(*pipe_).sink().close();
         this->pipe       = nullptr;
 
     }
@@ -122,34 +122,34 @@ struct async_out_future : ::boost::process::detail::windows::handler_base_ext,
     template <typename Executor>
     inline void on_success(Executor&)
     {
-        auto pipe    = this->pipe;
-        auto buffer  = this->buffer;
-        auto promise = this->promise;
-        std::move(*pipe).sink().close();
-        boost::asio::async_read(*pipe, *buffer,
-                [pipe, buffer, promise](const boost::system::error_code& ec, std::size_t)
+        auto pipe_    = this->pipe;
+        auto buffer_  = this->buffer;
+        auto promise_ = this->promise;
+        std::move(*pipe_).sink().close();
+        boost::asio::async_read(*pipe_, *buffer_,
+                [pipe_, buffer_, promise_](const boost::system::error_code& ec, std::size_t)
                 {
                     if (ec && (ec.value() != ::boost::winapi::ERROR_BROKEN_PIPE_))
                     {
                         std::error_code e(ec.value(), std::system_category());
-                        promise->set_exception(std::make_exception_ptr(process_error(e)));
+                        promise_->set_exception(std::make_exception_ptr(process_error(e)));
                     }
                     else
                     {
-                        std::istream is (buffer.get());
+                        std::istream is (buffer_.get());
                         Type arg;
-                        if (buffer->size() > 0)
+                        if (buffer_->size() > 0)
                         {
-                        	arg.resize(buffer->size());
-                        	is.read(&*arg.begin(), buffer->size());
+                          arg.resize(buffer_->size());
+                          is.read(&*arg.begin(), buffer_->size());
                         }
 
-                        promise->set_value(std::move(arg));
+                        promise_->set_value(std::move(arg));
 
 
                     }
                 });
-        this->pipe       = nullptr;
+        this->pipe    = nullptr;
         this->buffer  = nullptr;
         this->promise = nullptr;
 

--- a/include/boost/process/detail/windows/on_exit.hpp
+++ b/include/boost/process/detail/windows/on_exit.hpp
@@ -25,10 +25,10 @@ struct on_exit_ : boost::process::detail::windows::async_handler
     template<typename Executor>
     std::function<void(int, const std::error_code&)> on_exit_handler(Executor&)
     {
-        auto handler = this->handler;
-        return [handler](int exit_code, const std::error_code & ec)
+        auto handler_ = this->handler;
+        return [handler_](int exit_code, const std::error_code & ec)
                {
-                    handler(static_cast<int>(exit_code), ec);
+                    handler_(static_cast<int>(exit_code), ec);
                };
 
     }

--- a/include/boost/process/extend.hpp
+++ b/include/boost/process/extend.hpp
@@ -164,10 +164,10 @@ struct require_io_context {};
 template<typename Executor>
 std::function<void(int, const std::error_code&)> on_exit_handler(Executor & exec)
 {
-    auto handler = this->handler;
-    return [handler](int exit_code, const std::error_code & ec)
+    auto handler_ = this->handler;
+    return [handler_](int exit_code, const std::error_code & ec)
            {
-                handler(static_cast<int>(exit_code), ec);
+                handler_(static_cast<int>(exit_code), ec);
            };
 
 }


### PR DESCRIPTION
Address C4458 warnings when compiled with Visual C++