### PR TITLE
Allow access to the uninterpreted exit code

### DIFF
--- a/include/boost/process/child.hpp
+++ b/include/boost/process/child.hpp
@@ -92,6 +92,10 @@ class child
     /** Get the Process Identifier. */
     pid_t id()      const;
 
+    /** Get the native, uninterpreted exit code. The return value is without any meaning if the child wasn't waited
+     *  for or if it was terminated. */
+    int native_exit_code() const;
+
     /** Check if the child process is running. */
     bool running();
     /** \overload void running() */

--- a/include/boost/process/detail/child_decl.hpp
+++ b/include/boost/process/detail/child_decl.hpp
@@ -101,6 +101,8 @@ public:
     int exit_code() const {return ::boost::process::detail::api::eval_exit_status(_exit_status->load());}
     pid_t id()      const {return _child_handle.id(); }
 
+    int native_exit_code() const {return _exit_status->load();}
+
     bool running()
     {
         std::error_code ec;


### PR DESCRIPTION
Calling eval_exit_status on the exit obscures the reason for a child exit, whether it was a non-zero edit code or terminated due to signal. Providing access to the raw, native exit code provides more, but platform-specific, information to the calling code if desired.

Code for issue #184 