### PR TITLE
Fix pstream / opstream rdbuf() implementations

### DIFF
--- a/include/boost/process/pipe.hpp
+++ b/include/boost/process/pipe.hpp
@@ -346,7 +346,7 @@ public:
 
 
     ///Get access to the underlying stream_buf
-    basic_pipebuf<CharT, Traits>* rdbuf() const {return _buf;};
+    basic_pipebuf<CharT, Traits>* rdbuf() {return &_buf;};
 
     ///Default constructor.
     basic_opstream() : std::basic_ostream<CharT, Traits>(nullptr)
@@ -429,7 +429,7 @@ public:
 
 
     ///Get access to the underlying stream_buf
-    basic_pipebuf<CharT, Traits>* rdbuf() const {return _buf;};
+    basic_pipebuf<CharT, Traits>* rdbuf() {return &_buf;};
 
     ///Default constructor.
     basic_pstream() : std::basic_iostream<CharT, Traits>(nullptr)


### PR DESCRIPTION
This tries to fix pstream / opstream `rdbuf()` implementations

What is broken: `pipe.hpp`'s opstream / pstream `rdbuf()` functions

As far as I understand these member functions:
- the rdbuf() implementations need to be non-const member functions returning the address of the underlying rdbuf in order for istream / ostream operator << (basic_streambuf<...>) functions to work (see e.g. [subitem (11)](https://en.cppreference.com/w/cpp/io/basic_istream/operator_gtgt) )
- see also 3ab038fc0fe2592a3ed78055bdc2b9cad05cf0a4 for sehesnips' identical fix (unfortunately only applied to ipstream, not all the other pipe streams)

I'm not sure how to add tests, but a simple variant to make sure the relevant syntax is allowed could be something of this sort:

```c++
BOOST_AUTO_TEST_CASE(feed_pipes, *boost::unit_test::timeout(5))
{
    {
        std::istream is;
        std::ostream os;
        bp::ipstream ips;
        bp::opstream ops;
        bp::pstream ps;

        // These expressions should be valid:
        ips << is.rdbuf();
        os << ops.rdbuf();
        ps << is.rdbuf();
        os << ps.rdbuf();
    }
}
```