### PR TITLE
Close the read pipe after _read_error() completes

### DIFF
--- a/include/boost/process/detail/posix/executor.hpp
+++ b/include/boost/process/detail/posix/executor.hpp
@@ -283,7 +283,6 @@ class executor
         }
         if (count == 0)
         {
-            ::close(source);
             return  ;
         }
 
@@ -299,11 +298,9 @@ class executor
                 //EAGAIN not yet forked, EINTR interrupted, i.e. try again
             else if ((err != EAGAIN ) && (err != EINTR))
             {
-                ::close(source);
                 set_error(std::error_code(err, std::system_category()), "Error read pipe");
             }
         }
-        ::close(source);
         set_error(ec, std::move(msg));
     }
 
@@ -432,6 +429,7 @@ child executor<Sequence>::invoke(boost::mpl::false_, boost::mpl::false_)
 
     ::close(p[1]);
     _read_error(p[0]);
+    ::close(p[0]);
 
     if (_ec)
     {


### PR DESCRIPTION
There are exit conditions in _read_error() where the pipe does
not get closed resulting in a file descriptor leak in the
parent process after the child exits.

This change moves the responsibility to close the pipe out of
_read_error() to the caller of _read_error() which aligns
with the behavior of _write_error().