### PR TITLE
Use SIGTERM instead of `-15`.

### DIFF
--- a/include/boost/process/detail/posix/wait_for_exit.hpp
+++ b/include/boost/process/detail/posix/wait_for_exit.hpp
@@ -125,7 +125,7 @@ inline bool wait_until(
         ~child_cleaner_t()
         {
             int res;
-            ::kill(pid, -15);
+            ::kill(pid, SIGTERM);
             ::waitpid(pid, &res, WNOHANG);
         }
     };

--- a/include/boost/process/detail/posix/wait_group.hpp
+++ b/include/boost/process/detail/posix/wait_group.hpp
@@ -129,7 +129,7 @@ inline bool wait_until(
         ~child_cleaner_t()
         {
             int res;
-            ::kill(pid, -15);
+            ::kill(pid, SIGTERM);
             ::waitpid(pid, &res, WNOHANG);
         }
     };


### PR DESCRIPTION
On macOS, `SIGTERM` is `15`, not `-15`.  This was causing the forked child process to not exit and hang around when doing a call to `wait_for` or `wait_until`