### PR TITLE
Fixed file_descriptor move assignment operator returns a reference to this.

### DIFF
--- a/include/boost/process/detail/windows/file_descriptor.hpp
+++ b/include/boost/process/detail/windows/file_descriptor.hpp
@@ -102,6 +102,7 @@ struct file_descriptor
         if (_handle != ::boost::winapi::INVALID_HANDLE_VALUE_)
             ::boost::winapi::CloseHandle(_handle);
         _handle = boost::exchange(other._handle, ::boost::winapi::INVALID_HANDLE_VALUE_);
+        return &this;
     }
 
     ~file_descriptor()


### PR DESCRIPTION
To fix Issue #219 Added a return of a reference to "this".
The issue was discovered compiling in Clang 12 with the Visual Studio 2019 headers and libraries.