### PR TITLE
making _pipe_sink public

### DIFF
--- a/include/boost/process/detail/posix/executor.hpp
+++ b/include/boost/process/detail/posix/executor.hpp
@@ -147,7 +147,6 @@ class executor
     template<typename HasHandler, typename UseVFork>
     void internal_error_handle(const std::error_code&, const char*, HasHandler, boost::mpl::true_, UseVFork) {}
 
-    int _pipe_sink = -1;
 
     void write_error(const std::error_code & ec, const char * msg)
     {
@@ -318,6 +317,8 @@ public:
     std::shared_ptr<std::atomic<int>> exit_status = std::make_shared<std::atomic<int>>(still_active);
 
     const std::error_code & error() const {return _ec;}
+	int _pipe_sink = -1;
+
 
     void set_error(const std::error_code &ec, const char* msg)
     {


### PR DESCRIPTION
This change allowed me to close all file handles except one I specified in my on_exec_setup handler on POSIX platform.

This is really important feature to us. Since we don't want to share any of parent file descriptors to our children. 
We start large number of processes and as side effect all child processes are sharing pipes to other child processes which is not desirable. It often leads to 'Too many files open' error.